### PR TITLE
Add on-hold editing option

### DIFF
--- a/app/dashboard/src/components/UserDialog.tsx
+++ b/app/dashboard/src/components/UserDialog.tsx
@@ -482,8 +482,7 @@ export const UserDialog: FC<UserDialogProps> = () => {
                             )}
                           </HStack>
                         </FormControl>
-                        {!isEditing && (
-                          <FormControl flex="1">
+                        <FormControl flex="1">
                             <FormLabel whiteSpace={"nowrap"}>
                               {t("userDialog.onHold")}
                             </FormLabel>
@@ -514,7 +513,6 @@ export const UserDialog: FC<UserDialogProps> = () => {
                               }}
                             />
                           </FormControl>
-                        )}
                       </Flex>
                       <FormControl mb={"10px"}>
                         <FormLabel>{t("userDialog.dataLimit")}</FormLabel>


### PR DESCRIPTION
## Summary
- enable toggling the `on_hold` status when editing a user

## Testing
- `npm run build` *(fails: Cannot find module 'react', etc.)*

------
https://chatgpt.com/codex/tasks/task_b_6848c30d1978832d9f8f0dc3ecb214bc