### PR TITLE
Add on_hold option in user editor

### DIFF
--- a/app/dashboard/src/components/UserDialog.tsx
+++ b/app/dashboard/src/components/UserDialog.tsx
@@ -482,39 +482,37 @@ export const UserDialog: FC<UserDialogProps> = () => {
                             )}
                           </HStack>
                         </FormControl>
-                        {!isEditing && (
-                          <FormControl flex="1">
-                            <FormLabel whiteSpace={"nowrap"}>
-                              {t("userDialog.onHold")}
-                            </FormLabel>
-                            <Controller
-                              name="status"
-                              control={form.control}
-                              render={({ field }) => {
-                                const status = field.value;
-                                return (
-                                  <>
-                                    {status ? (
-                                      <Switch
-                                        colorScheme="primary"
-                                        isChecked={status === "on_hold"}
-                                        onChange={(e) => {
-                                          if (e.target.checked) {
-                                            field.onChange("on_hold");
-                                          } else {
-                                            field.onChange("active");
-                                          }
-                                        }}
-                                      />
-                                    ) : (
-                                      ""
-                                    )}
-                                  </>
-                                );
-                              }}
-                            />
-                          </FormControl>
-                        )}
+                        <FormControl flex="1">
+                          <FormLabel whiteSpace={"nowrap"}>
+                            {t("userDialog.onHold")}
+                          </FormLabel>
+                          <Controller
+                            name="status"
+                            control={form.control}
+                            render={({ field }) => {
+                              const status = field.value;
+                              return (
+                                <>
+                                  {status ? (
+                                    <Switch
+                                      colorScheme="primary"
+                                      isChecked={status === "on_hold"}
+                                      onChange={(e) => {
+                                        if (e.target.checked) {
+                                          field.onChange("on_hold");
+                                        } else {
+                                          field.onChange("active");
+                                        }
+                                      }}
+                                    />
+                                  ) : (
+                                    ""
+                                  )}
+                                </>
+                              );
+                            }}
+                          />
+                        </FormControl>
                       </Flex>
                       <FormControl mb={"10px"}>
                         <FormLabel>{t("userDialog.dataLimit")}</FormLabel>


### PR DESCRIPTION
## Summary
- allow editing the `on_hold` status in the dashboard user dialog

## Testing
- `npm run build` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_b_6848c46ffd34832db43f30f003503285