### PR TITLE
Fix bulk user dialog translation and sizes

### DIFF
--- a/app/dashboard/public/statics/locales/en.json
+++ b/app/dashboard/public/statics/locales/en.json
@@ -169,6 +169,7 @@
   "userDialog.selectOneProtocol": "Please select at least one protocol",
   "userDialog.shadowsocksDesc": "Fast and secure, but not efficient as others",
   "userDialog.startDate": "Start date",
+  "userDialog.bulkCount": "Number of Users",
   "userDialog.total": "Total: ",
   "userDialog.trojanDesc": "Lightweight, secure and lightening fast",
   "userDialog.usage": "Usage",

--- a/app/dashboard/public/statics/locales/fa.json
+++ b/app/dashboard/public/statics/locales/fa.json
@@ -175,6 +175,7 @@
   "userDialog.selectOneProtocol": "لطفا حداقل یک پروتکل انتخاب کنید",
   "userDialog.shadowsocksDesc": "سریع و امن، اما کارآمد کمتر از بقیه",
   "userDialog.startDate": "تاریخ شروع",
+  "userDialog.bulkCount": "تعداد کاربران",
   "userDialog.total": "مجموع: ",
   "userDialog.trojanDesc": "سبک، امن و فوق‌العاده سریع",
   "userDialog.usage": "مصرف",

--- a/app/dashboard/public/statics/locales/ru.json
+++ b/app/dashboard/public/statics/locales/ru.json
@@ -169,6 +169,7 @@
   "userDialog.selectOneProtocol": "Пожалуйста, выберите хотя бы один протокол",
   "userDialog.shadowsocksDesc": "Быстрый и безопасный, но не такой эффективный, как другие",
   "userDialog.startDate": "Дата начала",
+  "userDialog.bulkCount": "Количество пользователей",
   "userDialog.total": "Всего: ",
   "userDialog.trojanDesc": "Легковесный, безопасный и быстрый",
   "userDialog.usage": "Потребление",

--- a/app/dashboard/public/statics/locales/zh.json
+++ b/app/dashboard/public/statics/locales/zh.json
@@ -169,6 +169,7 @@
   "userDialog.selectOneProtocol": "请至少选择一个协议",
   "userDialog.shadowsocksDesc": "快速且安全, 但效率不如其它",
   "userDialog.startDate": "开始日期",
+  "userDialog.bulkCount": "数量",
   "userDialog.total": "总共：",
   "userDialog.trojanDesc": "轻量、安全且非常快",
   "userDialog.usage": "流量详情",

--- a/app/dashboard/src/components/UserDialog.tsx
+++ b/app/dashboard/src/components/UserDialog.tsx
@@ -469,7 +469,7 @@ export const UserDialog: FC<UserDialogProps> = () => {
                           </FormLabel>
                           <HStack>
                             <Input
-                              size="sm"
+                              size="md"
                               type="text"
                               borderRadius="6px"
                               error={form.formState.errors.username?.message}
@@ -519,7 +519,7 @@ export const UserDialog: FC<UserDialogProps> = () => {
                             <Input
                               type="number"
                               min={1}
-                              size="sm"
+                              size="xs"
                               borderRadius="6px"
                               disabled={disabled}
                               error={form.formState.errors.bulk_count?.message}


### PR DESCRIPTION
## Summary
- enlarge username input
- shrink bulk count input
- add missing `userDialog.bulkCount` translations for all locales

## Testing
- `npm run build` *(fails: Cannot find module)*

------
https://chatgpt.com/codex/tasks/task_b_6848d59e7520832d8f67c3727678ca53