### PR TITLE
Implement bulk username numbering

### DIFF
--- a/app/dashboard/src/components/UserDialog.tsx
+++ b/app/dashboard/src/components/UserDialog.tsx
@@ -331,13 +331,7 @@ export const UserDialog: FC<UserDialogProps> = () => {
       if (isBulkCreating && !isEditing) {
         const count = values.bulk_count || 1;
         for (let i = 0; i < count; i++) {
-          const match = values.username.match(/(\d+)$/);
-          const username =
-            i === 0
-              ? values.username
-              : match
-              ? values.username.replace(match[1], String(parseInt(match[1]) + i))
-              : values.username + (i + 1);
+          const username = `${values.username}_${i + 1}`;
           await createUser({ ...body, username });
         }
       } else {


### PR DESCRIPTION
## Summary
- add sequential numbering with underscores when creating users in bulk

## Testing
- `npm run build` *(fails: cannot find modules)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_6848e5bd9ef8832d899508df71fbf2b2