### PR TITLE
Add delay between bulk user creation requests

### DIFF
--- a/app/dashboard/src/components/UserDialog.tsx
+++ b/app/dashboard/src/components/UserDialog.tsx
@@ -334,6 +334,8 @@ export const UserDialog: FC<UserDialogProps> = () => {
           const username = `${values.username}_${i + 1}`;
           // Ensure each user is created sequentially
           await createUser({ ...body, username });
+          // Add a small delay between each creation
+          await new Promise((resolve) => setTimeout(resolve, 5));
         }
       } else {
         await create();


### PR DESCRIPTION
## Summary
- add a short delay when creating users in bulk

## Testing
- `npm run build` *(fails: cannot find module '@chakra-ui/react')*
- `npm ci` *(fails: network issues)*

------
https://chatgpt.com/codex/tasks/task_b_6848f2d81098832db466a080c6529b34