### PR TITLE
Add expired users cleanup option

### DIFF
--- a/app/dashboard/public/statics/locales/en.json
+++ b/app/dashboard/public/statics/locales/en.json
@@ -190,5 +190,10 @@
   "usersTable.noUser": "There is no user added to the system",
   "usersTable.noUserMatched": "It seems there is no user matched with what you are looking for",
   "usersTable.status": "status",
-  "usersTable.total": "Total"
+  "usersTable.total": "Total",
+  "deleteExpiredUsers.title": "Delete Expired Users",
+  "deleteExpiredUsers.prompt": "Days since expiration",
+  "deleteExpiredUsers.success": "Removed expired users: {{count}}",
+  "deleteExpiredUsers.error": "Invalid input or deletion failed"
 }
+

--- a/app/dashboard/public/statics/locales/fa.json
+++ b/app/dashboard/public/statics/locales/fa.json
@@ -196,5 +196,10 @@
   "usersTable.noUser": "کاربری افزوده نشده است",
   "usersTable.noUserMatched": "به‌نظر میرسه کاربری که جستجو کردید، وجود ندارد",
   "usersTable.status": "وضعیت",
-  "usersTable.total": "مجموع"
+  "usersTable.total": "مجموع",
+  "deleteExpiredUsers.title": "حذف کاربران منقضی",
+  "deleteExpiredUsers.prompt": "تعداد روزهای گذشته از انقضا",
+  "deleteExpiredUsers.success": "{{count}} کاربر منقضی حذف شد.",
+  "deleteExpiredUsers.error": "ورودی نامعتبر یا خطا در حذف"
 }
+

--- a/app/dashboard/public/statics/locales/ru.json
+++ b/app/dashboard/public/statics/locales/ru.json
@@ -190,5 +190,9 @@
   "usersTable.noUser": "В системе нет созданных пользователей",
   "usersTable.noUserMatched": "Похоже, нет пользователя, соответствующего вашему запросу",
   "usersTable.status": "Статус",
-  "usersTable.total": "Всего"
+  "usersTable.total": "Всего",
+  "deleteExpiredUsers.title": "Удалить просроченных пользователей",
+  "deleteExpiredUsers.prompt": "Количество дней после истечения",
+  "deleteExpiredUsers.success": "Удалено просроченных пользователей: {{count}}",
+  "deleteExpiredUsers.error": "Неверный ввод или ошибка удаления"
 }

--- a/app/dashboard/public/statics/locales/zh.json
+++ b/app/dashboard/public/statics/locales/zh.json
@@ -191,5 +191,9 @@
   "usersTable.noUserMatched": "没有找到您搜索的用户",
   "usersTable.status": "状态",
   "usersTable.sortByExpire": "按过期时间排序",
-  "usersTable.total": "总共"
+  "usersTable.total": "总共",
+  "deleteExpiredUsers.title": "删除过期用户",
+  "deleteExpiredUsers.prompt": "过期天数",
+  "deleteExpiredUsers.success": "已删除 {{count}} 个过期用户",
+  "deleteExpiredUsers.error": "输入无效或删除失败"
 }

--- a/app/dashboard/src/components/DeleteExpiredUsersModal.tsx
+++ b/app/dashboard/src/components/DeleteExpiredUsersModal.tsx
@@ -1,0 +1,125 @@
+import {
+  Button,
+  chakra,
+  Input,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Spinner,
+  Text,
+  useToast,
+} from "@chakra-ui/react";
+import { TrashIcon } from "@heroicons/react/24/outline";
+import { useDashboard } from "contexts/DashboardContext";
+import { FC, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Icon } from "./Icon";
+import subDays from "date-fns/subDays";
+
+export const DeleteExpiredIcon = chakra(TrashIcon, {
+  baseStyle: {
+    w: 5,
+    h: 5,
+  },
+});
+
+export const DeleteExpiredUsersModal: FC = () => {
+  const [loading, setLoading] = useState(false);
+  const [days, setDays] = useState("");
+  const {
+    isDeletingExpiredUsers,
+    onDeletingExpiredUsers,
+    deleteExpiredUsers,
+  } = useDashboard();
+  const { t } = useTranslation();
+  const toast = useToast();
+
+  const onClose = () => {
+    setDays("");
+    onDeletingExpiredUsers(false);
+  };
+
+  const onDelete = () => {
+    const d = parseInt(days, 10);
+    if (isNaN(d) || d <= 0) {
+      toast({
+        title: t("deleteExpiredUsers.error"),
+        status: "error",
+        isClosable: true,
+        position: "top",
+        duration: 3000,
+      });
+      return;
+    }
+    setLoading(true);
+    const expired_before = subDays(new Date(), d).toISOString();
+    const expired_after = "2000-01-01T00:00:00";
+    deleteExpiredUsers(expired_after, expired_before)
+      .then((removed) => {
+        toast({
+          title: t("deleteExpiredUsers.success", { count: removed.length }),
+          status: "success",
+          isClosable: true,
+          position: "top",
+          duration: 3000,
+        });
+      })
+      .catch(() => {
+        toast({
+          title: t("deleteExpiredUsers.error"),
+          status: "error",
+          isClosable: true,
+          position: "top",
+          duration: 3000,
+        });
+      })
+      .finally(() => {
+        setLoading(false);
+        onClose();
+      });
+  };
+
+  return (
+    <Modal isCentered isOpen={isDeletingExpiredUsers} onClose={onClose} size="sm">
+      <ModalOverlay bg="blackAlpha.300" backdropFilter="blur(10px)" />
+      <ModalContent mx="3">
+        <ModalHeader pt={6}>
+          <Icon color="red">
+            <DeleteExpiredIcon />
+          </Icon>
+        </ModalHeader>
+        <ModalCloseButton mt={3} />
+        <ModalBody>
+          <Text fontWeight="semibold" fontSize="lg">
+            {t("deleteExpiredUsers.title")}
+          </Text>
+          <Input
+            mt={4}
+            type="number"
+            value={days}
+            onChange={(e) => setDays(e.target.value)}
+            placeholder={t("deleteExpiredUsers.prompt") || undefined}
+          />
+        </ModalBody>
+        <ModalFooter display="flex">
+          <Button size="sm" onClick={onClose} mr={3} w="full" variant="outline">
+            {t("cancel")}
+          </Button>
+          <Button
+            size="sm"
+            w="full"
+            colorScheme="red"
+            onClick={onDelete}
+            leftIcon={loading ? <Spinner size="xs" /> : undefined}
+          >
+            {t("delete")}
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+};

--- a/app/dashboard/src/components/Header.tsx
+++ b/app/dashboard/src/components/Header.tsx
@@ -18,6 +18,7 @@ import {
   Cog6ToothIcon,
   CurrencyDollarIcon,
   DocumentMinusIcon,
+  TrashIcon,
   LinkIcon,
   MoonIcon,
   SquaresPlusIcon,
@@ -55,6 +56,7 @@ const HostsIcon = chakra(LinkIcon, iconProps);
 const NodesIcon = chakra(SquaresPlusIcon, iconProps);
 const NodesUsageIcon = chakra(ChartPieIcon, iconProps);
 const ResetUsageIcon = chakra(DocumentMinusIcon, iconProps);
+const DeleteExpiredIcon = chakra(TrashIcon, iconProps);
 const NotificationCircle = chakra(Box, {
   baseStyle: {
     bg: "yellow.500",
@@ -95,6 +97,7 @@ export const Header: FC<HeaderProps> = ({ actions }) => {
   const {
     onEditingHosts,
     onResetAllUsage,
+    onDeletingExpiredUsers,
     onEditingNodes,
     onShowingNodesUsage,
   } = useDashboard();
@@ -175,6 +178,14 @@ export const Header: FC<HeaderProps> = ({ actions }) => {
                     onClick={onResetAllUsage.bind(null, true)}
                   >
                     {t("resetAllUsage")}
+                  </MenuItem>
+                  <MenuItem
+                    maxW="170px"
+                    fontSize="sm"
+                    icon={<DeleteExpiredIcon />}
+                    onClick={onDeletingExpiredUsers.bind(null, true)}
+                  >
+                    {t("deleteExpiredUsers.title")}
                   </MenuItem>
                 </>
               )}

--- a/app/dashboard/src/contexts/DashboardContext.tsx
+++ b/app/dashboard/src/contexts/DashboardContext.tsx
@@ -48,6 +48,7 @@ type DashboardStateType = {
   isEditingNodes: boolean;
   isShowingNodesUsage: boolean;
   isResetingAllUsage: boolean;
+  isDeletingExpiredUsers: boolean;
   resetUsageUser: User | null;
   revokeSubscriptionUser: User | null;
   isEditingCore: boolean;
@@ -56,8 +57,10 @@ type DashboardStateType = {
   onEditingUser: (user: User | null) => void;
   onDeletingUser: (user: User | null) => void;
   onResetAllUsage: (isResetingAllUsage: boolean) => void;
+  onDeletingExpiredUsers: (isDeletingExpiredUsers: boolean) => void;
   refetchUsers: () => void;
   resetAllUsage: () => Promise<void>;
+  deleteExpiredUsers: (expired_after: string, expired_before: string) => Promise<string[]>;
   onFilterChange: (filters: Partial<FilterType>) => void;
   deleteUser: (user: User) => Promise<void>;
   createUser: (user: UserCreate) => Promise<void>;
@@ -114,6 +117,7 @@ export const useDashboard = create(
     },
     loading: true,
     isResetingAllUsage: false,
+    isDeletingExpiredUsers: false,
     isEditingHosts: false,
     isEditingNodes: false,
     isShowingNodesUsage: false,
@@ -136,6 +140,8 @@ export const useDashboard = create(
       });
     },
     onResetAllUsage: (isResetingAllUsage) => set({ isResetingAllUsage }),
+    onDeletingExpiredUsers: (isDeletingExpiredUsers) =>
+      set({ isDeletingExpiredUsers }),
     onCreateUser: (isCreatingNewUser) => set({ isCreatingNewUser }),
     onBulkCreate: (isBulkCreating) => set({ isBulkCreating }),
     onEditingUser: (editingUser) => {
@@ -211,6 +217,15 @@ export const useDashboard = create(
       }).then((user) => {
         set({ revokeSubscriptionUser: null, editingUser: user });
         get().refetchUsers();
+      });
+    },
+    deleteExpiredUsers: (expired_after, expired_before) => {
+      return fetch(`/users/expired`, {
+        method: "DELETE",
+        query: { expired_after, expired_before },
+      }).then((removed: string[]) => {
+        get().refetchUsers();
+        return removed;
       });
     },
   }))

--- a/app/dashboard/src/pages/Dashboard.tsx
+++ b/app/dashboard/src/pages/Dashboard.tsx
@@ -9,6 +9,7 @@ import { NodesDialog } from "components/NodesModal";
 import { NodesUsage } from "components/NodesUsage";
 import { QRCodeDialog } from "components/QRCodeDialog";
 import { ResetAllUsageModal } from "components/ResetAllUsageModal";
+import { DeleteExpiredUsersModal } from "components/DeleteExpiredUsersModal";
 import { ResetUserUsageModal } from "components/ResetUserUsageModal";
 import { RevokeSubscriptionModal } from "components/RevokeSubscriptionModal";
 import { UserDialog } from "components/UserDialog";
@@ -37,6 +38,7 @@ export const Dashboard: FC = () => {
         <RevokeSubscriptionModal />
         <NodesDialog />
         <NodesUsage />
+        <DeleteExpiredUsersModal />
         <ResetAllUsageModal />
         <CoreSettingsModal />
       </Box>


### PR DESCRIPTION
## Summary
- add DeleteExpiredUsersModal component
- wire delete expired users menu item in Header
- support deleting expired users via Dashboard context
- include modal in Dashboard page
- update locale files with translations

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_6848fb6f8484832db13f0bc3a39dc786