### PR TITLE
Fix Delete Expired Users menu

### DIFF
--- a/app/dashboard/src/components/DeleteExpiredUsersModal.tsx
+++ b/app/dashboard/src/components/DeleteExpiredUsersModal.tsx
@@ -29,7 +29,7 @@ export const DeleteExpiredIcon = chakra(TrashIcon, {
 });
 
 export const DeleteExpiredUsersModal: FC = () => {
-  const [days, setDays] = useState(0);
+  const [days, setDays] = useState("");
   const [loading, setLoading] = useState(false);
   const { isDeletingExpiredUsers, onDeletingExpiredUsers, deleteExpiredUsers } =
     useDashboard();
@@ -37,13 +37,13 @@ export const DeleteExpiredUsersModal: FC = () => {
   const toast = useToast();
 
   const onClose = () => {
-    setDays(0);
+    setDays("");
     onDeletingExpiredUsers(false);
   };
 
   const onDelete = () => {
     setLoading(true);
-    deleteExpiredUsers(days)
+    deleteExpiredUsers(Number(days))
       .then((removed) => {
         toast({
           title: t("deleteExpiredUsers.success", { count: removed.length }),
@@ -87,7 +87,7 @@ export const DeleteExpiredUsersModal: FC = () => {
             <Input
               type="number"
               value={days}
-              onChange={(e) => setDays(Number(e.target.value))}
+              onChange={(e) => setDays(e.target.value)}
             />
           </FormControl>
         </ModalBody>

--- a/app/dashboard/src/components/Header.tsx
+++ b/app/dashboard/src/components/Header.tsx
@@ -143,11 +143,11 @@ export const Header: FC<HeaderProps> = ({ actions }) => {
               }
               position="relative"
             ></MenuButton>
-            <MenuList minW="170px" zIndex={99999} className="menuList">
+            <MenuList minW="200px" zIndex={99999} className="menuList">
               {isSudo() && (
                 <>
                   <MenuItem
-                    maxW="170px"
+                    maxW="200px"
                     fontSize="sm"
                     icon={<HostsIcon />}
                     onClick={onEditingHosts.bind(null, true)}
@@ -155,7 +155,7 @@ export const Header: FC<HeaderProps> = ({ actions }) => {
                     {t("header.hostSettings")}
                   </MenuItem>
                   <MenuItem
-                    maxW="170px"
+                    maxW="200px"
                     fontSize="sm"
                     icon={<NodesIcon />}
                     onClick={onEditingNodes.bind(null, true)}
@@ -163,7 +163,7 @@ export const Header: FC<HeaderProps> = ({ actions }) => {
                     {t("header.nodeSettings")}
                   </MenuItem>
                   <MenuItem
-                    maxW="170px"
+                    maxW="200px"
                     fontSize="sm"
                     icon={<NodesUsageIcon />}
                     onClick={onShowingNodesUsage.bind(null, true)}
@@ -171,7 +171,7 @@ export const Header: FC<HeaderProps> = ({ actions }) => {
                     {t("header.nodesUsage")}
                   </MenuItem>
                   <MenuItem
-                    maxW="170px"
+                    maxW="200px"
                     fontSize="sm"
                     icon={<ResetUsageIcon />}
                     onClick={onResetAllUsage.bind(null, true)}
@@ -181,7 +181,7 @@ export const Header: FC<HeaderProps> = ({ actions }) => {
                 </>
               )}
               <MenuItem
-                maxW="170px"
+                maxW="200px"
                 fontSize="sm"
                 icon={<DeleteIcon />}
                 onClick={() => onDeletingExpiredUsers(true)}
@@ -190,7 +190,7 @@ export const Header: FC<HeaderProps> = ({ actions }) => {
               </MenuItem>
               {/* <Link to={DONATION_URL} target="_blank">
                 <MenuItem
-                  maxW="170px"
+                  maxW="200px"
                   fontSize="sm"
                   icon={<DonationIcon />}
                   position="relative"
@@ -203,7 +203,7 @@ export const Header: FC<HeaderProps> = ({ actions }) => {
                 </MenuItem>
               </Link> */}
               <Link to="/login">
-                <MenuItem maxW="170px" fontSize="sm" icon={<LogoutIcon />}>
+                <MenuItem maxW="200px" fontSize="sm" icon={<LogoutIcon />}>
                   {t("header.logout")}
                 </MenuItem>
               </Link>


### PR DESCRIPTION
## Summary
- expand Header menu item width to keep `Delete Expired Users` text on one line
- clear days input default value in DeleteExpiredUsersModal

## Testing
- `npm -C app/dashboard install`
- `npm -C app/dashboard run build`


------
https://chatgpt.com/codex/tasks/task_b_6849a3757300832d916ae6f02314571f