### PR TITLE
Fix Delete Expired Users menu icon size

### DIFF
--- a/app/dashboard/src/components/Header.tsx
+++ b/app/dashboard/src/components/Header.tsx
@@ -180,12 +180,12 @@ export const Header: FC<HeaderProps> = ({ actions }) => {
                   </MenuItem>
                 </>
               )}
-              <MenuItem
-                maxW="200px"
-                fontSize="sm"
-                icon={<DeleteIcon />}
-                onClick={() => onDeletingExpiredUsers(true)}
-              >
+                <MenuItem
+                  maxW="200px"
+                  fontSize="sm"
+                  icon={<DeleteIcon w={4} h={4} />}
+                  onClick={() => onDeletingExpiredUsers(true)}
+                >
                 {t("deleteExpiredUsers")}
               </MenuItem>
               {/* <Link to={DONATION_URL} target="_blank">


### PR DESCRIPTION
## Summary
- reduce Delete Expired Users menu icon to match other menu items

## Testing
- `npm run build` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_b_6849acdb877c832da30add22bbb0ecdd