### PR TITLE
Combine user creation buttons

### DIFF
--- a/app/dashboard/build/statics/locales/en.json
+++ b/app/dashboard/build/statics/locales/en.json
@@ -17,7 +17,6 @@
   "core.title": "Core Settings",
   "createNewUser": "Create new user",
   "createUser": "Create User",
-  "createBulkUsers": "Create Bulk Users",
   "dataUsage": "data usage",
   "dateFormat": "MMMM d, yyy",
   "delete": "Delete",

--- a/app/dashboard/build/statics/locales/fa.json
+++ b/app/dashboard/build/statics/locales/fa.json
@@ -17,7 +17,6 @@
   "core.title": "تنظیمات هسته",
   "createNewUser": "ساخت کاربر",
   "createUser": "افزودن کاربر",
-  "createBulkUsers": "ساخت دسته‌جمعی کاربر",
   "dataUsage": "مصرف داده",
   "dateFormat": "MM/dd/yyyy",
   "dateInfo.day": " روز",

--- a/app/dashboard/build/statics/locales/ru.json
+++ b/app/dashboard/build/statics/locales/ru.json
@@ -17,7 +17,6 @@
   "core.title": "Основные настройки",
   "createNewUser": "Создать нового пользователя",
   "createUser": "Создать",
-  "createBulkUsers": "Создать нескольких пользователей",
   "dataUsage": "Трафик",
   "dateFormat": "MMMM d, yyy",
   "delete": "Удалить",

--- a/app/dashboard/build/statics/locales/zh.json
+++ b/app/dashboard/build/statics/locales/zh.json
@@ -17,7 +17,6 @@
   "core.title": "核心设置",
   "createNewUser": "创建新用户",
   "createUser": "创建用户",
-  "createBulkUsers": "批量创建用户",
   "dataUsage": "总流量",
   "dateFormat": "MM/dd/yyyy",
   "delete": "删除",

--- a/app/dashboard/public/statics/locales/en.json
+++ b/app/dashboard/public/statics/locales/en.json
@@ -17,7 +17,6 @@
   "core.title": "Core Settings",
   "createNewUser": "Create new user",
   "createUser": "Create User",
-  "createBulkUsers": "Create Bulk Users",
   "dataUsage": "data usage",
   "dateFormat": "MMMM d, yyy",
   "delete": "Delete",

--- a/app/dashboard/public/statics/locales/fa.json
+++ b/app/dashboard/public/statics/locales/fa.json
@@ -17,7 +17,6 @@
   "core.title": "تنظیمات هسته",
   "createNewUser": "ساخت کاربر",
   "createUser": "افزودن کاربر",
-  "createBulkUsers": "ساخت دسته‌جمعی کاربر",
   "dataUsage": "مصرف داده",
   "dateFormat": "MM/dd/yyyy",
   "dateInfo.day": " روز",

--- a/app/dashboard/public/statics/locales/ru.json
+++ b/app/dashboard/public/statics/locales/ru.json
@@ -17,7 +17,6 @@
   "core.title": "Основные настройки",
   "createNewUser": "Создать нового пользователя",
   "createUser": "Создать",
-  "createBulkUsers": "Создать нескольких пользователей",
   "dataUsage": "Трафик",
   "dateFormat": "MMMM d, yyy",
   "delete": "Удалить",

--- a/app/dashboard/public/statics/locales/zh.json
+++ b/app/dashboard/public/statics/locales/zh.json
@@ -17,7 +17,6 @@
   "core.title": "核心设置",
   "createNewUser": "创建新用户",
   "createUser": "创建用户",
-  "createBulkUsers": "批量创建用户",
   "dataUsage": "总流量",
   "dateFormat": "MM/dd/yyyy",
   "delete": "删除",

--- a/app/dashboard/src/components/Filters.tsx
+++ b/app/dashboard/src/components/Filters.tsx
@@ -50,7 +50,6 @@ export const Filters: FC<FilterProps> = ({ ...props }) => {
     onFilterChange,
     refetchUsers,
     onCreateUser,
-    onBulkCreate,
   } = useDashboard();
   const { t } = useTranslation();
   const [search, setSearch] = useState("");
@@ -135,17 +134,6 @@ export const Filters: FC<FilterProps> = ({ ...props }) => {
             px={5}
           >
             {t("createUser")}
-          </Button>
-          <Button
-            colorScheme="primary"
-            size="sm"
-            onClick={() => {
-              onBulkCreate(true);
-              onCreateUser(true);
-            }}
-            px={5}
-          >
-            {t("createBulkUsers")}
           </Button>
         </HStack>
       </GridItem>

--- a/app/dashboard/src/components/UserDialog.tsx
+++ b/app/dashboard/src/components/UserDialog.tsx
@@ -220,9 +220,7 @@ export const UserDialog: FC<UserDialogProps> = () => {
   const {
     editingUser,
     isCreatingNewUser,
-    isBulkCreating,
     onCreateUser,
-    onBulkCreate,
     editUser,
     fetchUserUsage,
     onEditingUser,
@@ -328,8 +326,8 @@ export const UserDialog: FC<UserDialogProps> = () => {
       });
 
     try {
-      if (isBulkCreating && !isEditing) {
-        const count = values.bulk_count || 1;
+      const count = values.bulk_count || 1;
+      if (!isEditing && count > 1) {
         for (let i = 0; i < count; i++) {
           const username = `${values.username}_${i + 1}`;
           // Ensure each user is created sequentially
@@ -364,7 +362,6 @@ export const UserDialog: FC<UserDialogProps> = () => {
   const onClose = () => {
     form.reset(getDefaultValues());
     onCreateUser(false);
-    onBulkCreate(false);
     onEditingUser(null);
     setError(null);
     setUsageVisible(false);
@@ -535,7 +532,7 @@ export const UserDialog: FC<UserDialogProps> = () => {
                           </FormControl>
                         )}
                       </Flex>
-                      {!isEditing && isBulkCreating && (
+                      {!isEditing && (
                         <FormControl mb={"10px"}>
                           <FormLabel>{t("userDialog.bulkCount")}</FormLabel>
                           <Controller

--- a/app/dashboard/src/components/UsersTable.tsx
+++ b/app/dashboard/src/components/UsersTable.tsx
@@ -764,7 +764,7 @@ type EmptySectionProps = {
 };
 
 const EmptySection: FC<EmptySectionProps> = ({ isFiltered }) => {
-  const { onCreateUser, onBulkCreate } = useDashboard();
+  const { onCreateUser } = useDashboard();
   return (
     <Box
       padding="5"
@@ -808,18 +808,6 @@ const EmptySection: FC<EmptySectionProps> = ({ isFiltered }) => {
           onClick={() => onCreateUser(true)}
         >
           {t("createUser")}
-        </Button>
-      )}
-      {!isFiltered && (
-        <Button
-          size="sm"
-          colorScheme="primary"
-          onClick={() => {
-            onBulkCreate(true);
-            onCreateUser(true);
-          }}
-        >
-          {t("createBulkUsers")}
         </Button>
       )}
     </Box>

--- a/app/dashboard/src/contexts/DashboardContext.tsx
+++ b/app/dashboard/src/contexts/DashboardContext.tsx
@@ -31,7 +31,6 @@ export type Inbounds = Map<ProtocolType, InboundType[]>;
 
 type DashboardStateType = {
   isCreatingNewUser: boolean;
-  isBulkCreating: boolean;
   editingUser: User | null | undefined;
   deletingUser: User | null;
   version: string | null;
@@ -53,7 +52,6 @@ type DashboardStateType = {
   revokeSubscriptionUser: User | null;
   isEditingCore: boolean;
   onCreateUser: (isOpen: boolean) => void;
-  onBulkCreate: (isBulk: boolean) => void;
   onEditingUser: (user: User | null) => void;
   onDeletingUser: (user: User | null) => void;
   onResetAllUsage: (isResetingAllUsage: boolean) => void;
@@ -108,7 +106,6 @@ export const useDashboard = create(
     editingUser: null,
     deletingUser: null,
     isCreatingNewUser: false,
-    isBulkCreating: false,
     QRcodeLinks: null,
     subscribeUrl: null,
     users: {
@@ -154,7 +151,6 @@ export const useDashboard = create(
     onDeletingExpiredUsers: (isDeletingExpiredUsers) =>
       set({ isDeletingExpiredUsers }),
     onCreateUser: (isCreatingNewUser) => set({ isCreatingNewUser }),
-    onBulkCreate: (isBulkCreating) => set({ isBulkCreating }),
     onEditingUser: (editingUser) => {
       set({ editingUser });
     },


### PR DESCRIPTION
## Summary
- drop `createBulkUsers` labels from locales
- remove bulk user button from Filters
- remove bulk user button from UsersTable
- simplify DashboardContext state
- show bulk user count field in UserDialog

## Testing
- `yarn build` *(fails: Cannot find module '@remix-run/router')*

------
https://chatgpt.com/codex/tasks/task_b_6849ae57d438832d902d94291c15d9c8