### PR TITLE
Show active protocols only in user dialog

### DIFF
--- a/app/dashboard/src/components/UserDialog.tsx
+++ b/app/dashboard/src/components/UserDialog.tsx
@@ -226,6 +226,7 @@ export const UserDialog: FC<UserDialogProps> = () => {
     onEditingUser,
     createUser,
     onDeletingUser,
+    inbounds,
   } = useDashboard();
   const isEditing = !!editingUser;
   const isOpen = isCreatingNewUser || isEditing;
@@ -240,6 +241,13 @@ export const UserDialog: FC<UserDialogProps> = () => {
   const handleUsageToggle = () => {
     setUsageVisible((current) => !current);
   };
+
+  const protocolsList = [
+    { title: "vmess", description: t("userDialog.vmessDesc") },
+    { title: "vless", description: t("userDialog.vlessDesc") },
+    { title: "trojan", description: t("userDialog.trojanDesc") },
+    { title: "shadowsocks", description: t("userDialog.shadowsocksDesc") },
+  ].filter(({ title }) => (inbounds.get(title as any) || []).length > 0);
 
   const form = useForm<FormType>({
     defaultValues: getDefaultValues(),
@@ -765,24 +773,7 @@ export const UserDialog: FC<UserDialogProps> = () => {
                       render={({ field }) => {
                         return (
                           <RadioGroup
-                            list={[
-                              {
-                                title: "vmess",
-                                description: t("userDialog.vmessDesc"),
-                              },
-                              {
-                                title: "vless",
-                                description: t("userDialog.vlessDesc"),
-                              },
-                              {
-                                title: "trojan",
-                                description: t("userDialog.trojanDesc"),
-                              },
-                              {
-                                title: "shadowsocks",
-                                description: t("userDialog.shadowsocksDesc"),
-                              },
-                            ]}
+                            list={protocolsList}
                             disabled={disabled}
                             {...field}
                           />


### PR DESCRIPTION
## Summary
- filter protocol list in UserDialog by active inbounds
- display only enabled protocols when creating a user

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_6849c514db14832d8253de9353f63828