### PR TITLE
Add bulk user deletion with checkboxes

### DIFF
--- a/app/dashboard/build/statics/locales/en.json
+++ b/app/dashboard/build/statics/locales/en.json
@@ -188,5 +188,10 @@
   "usersTable.noUser": "There is no user added to the system",
   "usersTable.noUserMatched": "It seems there is no user matched with what you are looking for",
   "usersTable.status": "status",
-  "usersTable.total": "Total"
+  "usersTable.total": "Total",
+  "deleteSelected": "Delete Selected",
+  "deleteSelectedUsers.title": "Delete Selected Users",
+  "deleteSelectedUsers.prompt": "Are you sure you want to delete {{count}} selected users?",
+  "deleteSelectedUsers.success": "{{count}} users deleted."
 }
+

--- a/app/dashboard/build/statics/locales/fa.json
+++ b/app/dashboard/build/statics/locales/fa.json
@@ -194,5 +194,10 @@
   "usersTable.noUser": "کاربری افزوده نشده است",
   "usersTable.noUserMatched": "به‌نظر میرسه کاربری که جستجو کردید، وجود ندارد",
   "usersTable.status": "وضعیت",
-  "usersTable.total": "مجموع"
+  "usersTable.total": "مجموع",
+  "deleteSelected": "حذف موارد انتخاب شده",
+  "deleteSelectedUsers.title": "حذف کاربران انتخاب شده",
+  "deleteSelectedUsers.prompt": "آیا از حذف {{count}} کاربر انتخاب شده مطمئن هستید؟",
+  "deleteSelectedUsers.success": "{{count}} کاربر حذف شد."
 }
+

--- a/app/dashboard/build/statics/locales/ru.json
+++ b/app/dashboard/build/statics/locales/ru.json
@@ -188,5 +188,11 @@
   "usersTable.noUser": "В системе нет созданных пользователей",
   "usersTable.noUserMatched": "Похоже, нет пользователя, соответствующего вашему запросу",
   "usersTable.status": "Статус",
-  "usersTable.total": "Всего"
+  "usersTable.total": "Всего",
+  "deleteSelected": "Удалить выбранные",
+  "deleteSelectedUsers.title": "Удалить выбранных пользователей",
+  "deleteSelectedUsers.prompt": "Вы уверены, что хотите удалить выбранных пользователей ({{count}})?",
+  "deleteSelectedUsers.success": "Удалено пользователей: {{count}}."
 }
+
+

--- a/app/dashboard/build/statics/locales/zh.json
+++ b/app/dashboard/build/statics/locales/zh.json
@@ -190,4 +190,9 @@
   "usersTable.status": "状态",
   "usersTable.sortByExpire": "按过期时间排序",
   "usersTable.total": "总共",
+  "deleteSelected": "删除已选",
+  "deleteSelectedUsers.title": "删除已选用户",
+  "deleteSelectedUsers.prompt": "确定删除选中的 {{count}} 个用户吗？",
+  "deleteSelectedUsers.success": "已删除 {{count}} 个用户。"
 }
+

--- a/app/dashboard/public/statics/locales/en.json
+++ b/app/dashboard/public/statics/locales/en.json
@@ -194,5 +194,10 @@
   "usersTable.noUser": "There is no user added to the system",
   "usersTable.noUserMatched": "It seems there is no user matched with what you are looking for",
   "usersTable.status": "status",
-  "usersTable.total": "Total"
+  "usersTable.total": "Total",
+  "deleteSelected": "Delete Selected",
+  "deleteSelectedUsers.title": "Delete Selected Users",
+  "deleteSelectedUsers.prompt": "Are you sure you want to delete {{count}} selected users?",
+  "deleteSelectedUsers.success": "{{count}} users deleted."
 }
+

--- a/app/dashboard/public/statics/locales/fa.json
+++ b/app/dashboard/public/statics/locales/fa.json
@@ -200,5 +200,10 @@
   "usersTable.noUser": "کاربری افزوده نشده است",
   "usersTable.noUserMatched": "به‌نظر میرسه کاربری که جستجو کردید، وجود ندارد",
   "usersTable.status": "وضعیت",
-  "usersTable.total": "مجموع"
+  "usersTable.total": "مجموع",
+  "deleteSelected": "حذف موارد انتخاب شده",
+  "deleteSelectedUsers.title": "حذف کاربران انتخاب شده",
+  "deleteSelectedUsers.prompt": "آیا از حذف {{count}} کاربر انتخاب شده مطمئن هستید؟",
+  "deleteSelectedUsers.success": "{{count}} کاربر حذف شد."
 }
+

--- a/app/dashboard/public/statics/locales/ru.json
+++ b/app/dashboard/public/statics/locales/ru.json
@@ -194,5 +194,10 @@
   "usersTable.noUser": "В системе нет созданных пользователей",
   "usersTable.noUserMatched": "Похоже, нет пользователя, соответствующего вашему запросу",
   "usersTable.status": "Статус",
-  "usersTable.total": "Всего"
+  "usersTable.total": "Всего",
+  "deleteSelected": "Удалить выбранные",
+  "deleteSelectedUsers.title": "Удалить выбранных пользователей",
+  "deleteSelectedUsers.prompt": "Вы уверены, что хотите удалить выбранных пользователей ({{count}})?",
+  "deleteSelectedUsers.success": "Удалено пользователей: {{count}}."
 }
+

--- a/app/dashboard/public/statics/locales/zh.json
+++ b/app/dashboard/public/statics/locales/zh.json
@@ -195,5 +195,10 @@
   "usersTable.noUserMatched": "没有找到您搜索的用户",
   "usersTable.status": "状态",
   "usersTable.sortByExpire": "按过期时间排序",
-  "usersTable.total": "总共"
+  "usersTable.total": "总共",
+  "deleteSelected": "删除已选",
+  "deleteSelectedUsers.title": "删除已选用户",
+  "deleteSelectedUsers.prompt": "确定删除选中的 {{count}} 个用户吗？",
+  "deleteSelectedUsers.success": "已删除 {{count}} 个用户。"
 }
+

--- a/app/dashboard/src/components/DeleteSelectedUsersModal.tsx
+++ b/app/dashboard/src/components/DeleteSelectedUsersModal.tsx
@@ -1,0 +1,90 @@
+import {
+  Button,
+  chakra,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Spinner,
+  Text,
+  useToast,
+} from "@chakra-ui/react";
+import { TrashIcon } from "@heroicons/react/24/outline";
+import { useDashboard } from "contexts/DashboardContext";
+import { FC, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Icon } from "./Icon";
+
+export const DeleteSelectedIcon = chakra(TrashIcon, {
+  baseStyle: {
+    w: 5,
+    h: 5,
+  },
+});
+
+export const DeleteSelectedUsersModal: FC = () => {
+  const [loading, setLoading] = useState(false);
+  const {
+    selectedUsers,
+    isDeletingSelectedUsers,
+    onDeletingSelectedUsers,
+    deleteSelectedUsers,
+  } = useDashboard();
+  const { t } = useTranslation();
+  const toast = useToast();
+  const onClose = () => onDeletingSelectedUsers(false);
+  const onDelete = () => {
+    setLoading(true);
+    deleteSelectedUsers()
+      .then(() => {
+        toast({
+          title: t("deleteSelectedUsers.success", { count: selectedUsers.length }),
+          status: "success",
+          isClosable: true,
+          position: "top",
+          duration: 3000,
+        });
+      })
+      .then(onClose)
+      .finally(() => setLoading(false));
+  };
+  return (
+    <Modal isCentered isOpen={isDeletingSelectedUsers} onClose={onClose} size="sm">
+      <ModalOverlay bg="blackAlpha.300" backdropFilter="blur(10px)" />
+      <ModalContent mx="3">
+        <ModalHeader pt={6}>
+          <Icon color="red">
+            <DeleteSelectedIcon />
+          </Icon>
+        </ModalHeader>
+        <ModalCloseButton mt={3} />
+        <ModalBody>
+          <Text fontWeight="semibold" fontSize="lg">
+            {t("deleteSelectedUsers.title")}
+          </Text>
+          <Text mt={1} fontSize="sm" _dark={{ color: "gray.400" }} color="gray.600">
+            {t("deleteSelectedUsers.prompt", { count: selectedUsers.length })}
+          </Text>
+        </ModalBody>
+        <ModalFooter display="flex">
+          <Button size="sm" onClick={onClose} mr={3} w="full" variant="outline">
+            {t("cancel")}
+          </Button>
+          <Button
+            size="sm"
+            w="full"
+            colorScheme="red"
+            onClick={onDelete}
+            leftIcon={loading ? <Spinner size="xs" /> : undefined}
+          >
+            {t("delete")}
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+};
+

--- a/app/dashboard/src/components/Filters.tsx
+++ b/app/dashboard/src/components/Filters.tsx
@@ -50,6 +50,8 @@ export const Filters: FC<FilterProps> = ({ ...props }) => {
     onFilterChange,
     refetchUsers,
     onCreateUser,
+    selectedUsers,
+    onDeletingSelectedUsers,
   } = useDashboard();
   const { t } = useTranslation();
   const [search, setSearch] = useState("");
@@ -127,6 +129,14 @@ export const Filters: FC<FilterProps> = ({ ...props }) => {
               })}
             />
           </IconButton>
+          <Button
+            colorScheme="red"
+            size="sm"
+            isDisabled={selectedUsers.length === 0}
+            onClick={() => onDeletingSelectedUsers(true)}
+          >
+            {t("deleteSelected")}
+          </Button>
           <Button
             colorScheme="primary"
             size="sm"

--- a/app/dashboard/src/components/UsersTable.tsx
+++ b/app/dashboard/src/components/UsersTable.tsx
@@ -25,6 +25,7 @@ import {
   Tr,
   useBreakpointValue,
   VStack,
+  Checkbox,
 } from "@chakra-ui/react";
 import {
   CheckIcon,
@@ -193,6 +194,10 @@ export const UsersTable: FC<UsersTableProps> = (props) => {
     users: totalUsers,
     onEditingUser,
     onFilterChange,
+    selectedUsers,
+    toggleSelectedUser,
+    clearSelectedUsers,
+    setSelectedUsers,
   } = useDashboard();
 
   const { t } = useTranslation();
@@ -213,6 +218,14 @@ export const UsersTable: FC<UsersTableProps> = (props) => {
   }, []);
 
   const isFiltered = users.length !== totalUsers.total;
+  const allSelected = users.length > 0 && users.every((u) => selectedUsers.includes(u.username));
+  const toggleSelectAll = () => {
+    if (allSelected) {
+      clearSelectedUsers();
+    } else {
+      setSelectedUsers(users.map((u) => u.username));
+    }
+  };
 
   const handleSort = (column: string) => {
     let newSort = filters.sort;
@@ -249,6 +262,13 @@ export const UsersTable: FC<UsersTableProps> = (props) => {
         <Table orientation="vertical" zIndex="docked" {...props}>
           <Thead zIndex="docked" position="relative">
             <Tr>
+              <Th position="sticky" top={top} w="40px" p={0}>
+                <Checkbox
+                  size="sm"
+                  isChecked={allSelected}
+                  onChange={toggleSelectAll}
+                />
+              </Th>
               <Th
                 position="sticky"
                 top={top}
@@ -342,13 +362,23 @@ export const UsersTable: FC<UsersTableProps> = (props) => {
               users?.map((user, i) => {
                 return (
                   <Fragment key={user.username}>
-                    <Tr
-                      onClick={toggleAccordion.bind(null, i)}
-                      cursor="pointer"
-                    >
-                      <Td
-                        borderBottom={0}
-                        minW="100px"
+                  <Tr
+                    onClick={toggleAccordion.bind(null, i)}
+                    cursor="pointer"
+                  >
+                    <Td borderBottom={0} p={0} w="40px" minW="40px">
+                      <Checkbox
+                        size="sm"
+                        isChecked={selectedUsers.includes(user.username)}
+                        onChange={(e) => {
+                          e.stopPropagation();
+                          toggleSelectedUser(user.username);
+                        }}
+                      />
+                    </Td>
+                    <Td
+                      borderBottom={0}
+                      minW="100px"
                         pl={4}
                         pr={4}
                         maxW="calc(100vw - 50px - 32px - 100px - 48px)"
@@ -394,7 +424,7 @@ export const UsersTable: FC<UsersTableProps> = (props) => {
                       className="collapsible"
                       onClick={toggleAccordion.bind(null, i)}
                     >
-                      <Td p={0} colSpan={4}>
+                      <Td p={0} colSpan={5}>
                         <AccordionItem border={0}>
                           <AccordionButton display="none"></AccordionButton>
                           <AccordionPanel
@@ -492,6 +522,9 @@ export const UsersTable: FC<UsersTableProps> = (props) => {
       >
         <Thead zIndex="docked" position="relative">
           <Tr>
+            <Th position="sticky" top={{ base: "unset", md: top }} w="40px" p={0}>
+              <Checkbox size="sm" isChecked={allSelected} onChange={toggleSelectAll} />
+            </Th>
             <Th
               position="sticky"
               top={{ base: "unset", md: top }}
@@ -590,6 +623,16 @@ export const UsersTable: FC<UsersTableProps> = (props) => {
                   })}
                   onClick={() => onEditingUser(user)}
                 >
+                  <Td w="40px" minW="40px" p={0}>
+                    <Checkbox
+                      size="sm"
+                      isChecked={selectedUsers.includes(user.username)}
+                      onChange={(e) => {
+                        e.stopPropagation();
+                        toggleSelectedUser(user.username);
+                      }}
+                    />
+                  </Td>
                   <Td minW="140px">
                     <div className="flex-status">
                       <OnlineBadge lastOnline={user.online_at} />
@@ -620,7 +663,7 @@ export const UsersTable: FC<UsersTableProps> = (props) => {
             })}
           {users.length == 0 && (
             <Tr>
-              <Td colSpan={4}>
+              <Td colSpan={5}>
                 <EmptySection isFiltered={isFiltered} />
               </Td>
             </Tr>

--- a/app/dashboard/src/contexts/DashboardContext.tsx
+++ b/app/dashboard/src/contexts/DashboardContext.tsx
@@ -50,10 +50,13 @@ type DashboardStateType = {
   isDeletingExpiredUsers: boolean;
   resetUsageUser: User | null;
   revokeSubscriptionUser: User | null;
+  selectedUsers: string[];
+  isDeletingSelectedUsers: boolean;
   isEditingCore: boolean;
   onCreateUser: (isOpen: boolean) => void;
   onEditingUser: (user: User | null) => void;
   onDeletingUser: (user: User | null) => void;
+  onDeletingSelectedUsers: (v: boolean) => void;
   onResetAllUsage: (isResetingAllUsage: boolean) => void;
   onDeletingExpiredUsers: (isDeletingExpiredUsers: boolean) => void;
   refetchUsers: () => void;
@@ -61,6 +64,10 @@ type DashboardStateType = {
   deleteExpiredUsers: (days: number) => Promise<string[]>;
   onFilterChange: (filters: Partial<FilterType>) => void;
   deleteUser: (user: User) => Promise<void>;
+  deleteSelectedUsers: () => Promise<void>;
+  toggleSelectedUser: (username: string) => void;
+  clearSelectedUsers: () => void;
+  setSelectedUsers: (users: string[]) => void;
   createUser: (user: UserCreate) => Promise<void>;
   editUser: (user: UserCreate) => Promise<void>;
   fetchUserUsage: (user: User, query: FilterUsageType) => Promise<void>;
@@ -120,6 +127,8 @@ export const useDashboard = create(
     isShowingNodesUsage: false,
     resetUsageUser: null,
     revokeSubscriptionUser: null,
+    selectedUsers: [],
+    isDeletingSelectedUsers: false,
     filters: {
       username: "",
       limit: getUsersPerPageLimitSize(),
@@ -169,10 +178,29 @@ export const useDashboard = create(
     setQRCode: (QRcodeLinks) => {
       set({ QRcodeLinks });
     },
+    toggleSelectedUser: (username) => {
+      const selected = new Set(get().selectedUsers);
+      if (selected.has(username)) selected.delete(username);
+      else selected.add(username);
+      set({ selectedUsers: Array.from(selected) });
+    },
+    clearSelectedUsers: () => set({ selectedUsers: [] }),
+    setSelectedUsers: (users) => set({ selectedUsers: Array.from(new Set(users)) }),
+    onDeletingSelectedUsers: (v) => set({ isDeletingSelectedUsers: v }),
     deleteUser: (user: User) => {
       set({ editingUser: null });
       return fetch(`/user/${user.username}`, { method: "DELETE" }).then(() => {
         set({ deletingUser: null });
+        get().refetchUsers();
+        queryClient.invalidateQueries(StatisticsQueryKey);
+      });
+    },
+    deleteSelectedUsers: () => {
+      const names = get().selectedUsers;
+      return Promise.all(
+        names.map((u) => fetch(`/user/${u}`, { method: "DELETE" }))
+      ).then(() => {
+        set({ selectedUsers: [] });
         get().refetchUsers();
         queryClient.invalidateQueries(StatisticsQueryKey);
       });

--- a/app/dashboard/src/pages/Dashboard.tsx
+++ b/app/dashboard/src/pages/Dashboard.tsx
@@ -1,6 +1,7 @@
 import { Box, VStack } from "@chakra-ui/react";
 import { CoreSettingsModal } from "components/CoreSettingsModal";
 import { DeleteUserModal } from "components/DeleteUserModal";
+import { DeleteSelectedUsersModal } from "components/DeleteSelectedUsersModal";
 import { Filters } from "components/Filters";
 import { Footer } from "components/Footer";
 import { Header } from "components/Header";
@@ -32,6 +33,7 @@ export const Dashboard: FC = () => {
         <UsersTable />
         <UserDialog />
         <DeleteUserModal />
+        <DeleteSelectedUsersModal />
         <QRCodeDialog />
         <HostsDialog />
         <ResetUserUsageModal />


### PR DESCRIPTION
## Summary
- add ability to select multiple users and delete them at once
- show delete selected button in filters
- update dashboard context to track selected users
- support bulk delete modal
- add translations for new strings

## Testing
- `npm --prefix app/dashboard run build` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_b_6849dc6933b8832d80741261abae7ac0