### PR TITLE
Display data usage in GB

### DIFF
--- a/app/dashboard/src/components/Statistics.tsx
+++ b/app/dashboard/src/components/Statistics.tsx
@@ -8,7 +8,7 @@ import { FC, PropsWithChildren, ReactElement, ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import { useQuery } from "react-query";
 import { fetch } from "service/http";
-import { formatBytes, numberWithCommas } from "utils/formatByte";
+import { formatBytes, formatGB, numberWithCommas } from "utils/formatByte";
 
 const TotalUsersIcon = chakra(UsersIcon, {
   baseStyle: {
@@ -152,7 +152,7 @@ export const Statistics: FC<BoxProps> = (props) => {
       />
       <StatisticCard
         title={t("dataUsage")}
-        content={systemData && formatBytes(systemData.admin_usage)}
+        content={systemData && formatGB(systemData.admin_usage)}
         icon={<NetworkIcon />}
       />
     </HStack>

--- a/app/dashboard/src/utils/formatByte.tsx
+++ b/app/dashboard/src/utils/formatByte.tsx
@@ -11,6 +11,14 @@ export function formatBytes(bytes: number, decimals = 2, asArray = false) {
   else return [parseFloat((bytes / Math.pow(k, i)).toFixed(dm)), sizes[i]];
 }
 
+export function formatGB(bytes: number, decimals = 2) {
+  if (!+bytes) return "0 GB";
+
+  const k = 1024;
+  const dm = decimals < 0 ? 0 : decimals;
+  return `${parseFloat((bytes / Math.pow(k, 3)).toFixed(dm))} GB`;
+}
+
 export const numberWithCommas = (x: number) => {
   if (x !== null) return x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
 };


### PR DESCRIPTION
## Summary
- add `formatGB` helper to present bytes in GB
- use `formatGB` in statistics widget

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_684a158402d8832d835936c9d7f7069e