### PR TITLE
Adjust statistics number font size

### DIFF
--- a/app/dashboard/src/components/Statistics.tsx
+++ b/app/dashboard/src/components/Statistics.tsx
@@ -101,7 +101,7 @@ const StatisticCard: FC<PropsWithChildren<StatisticCardProps>> = ({
           {title}
         </Text>
       </HStack>
-      <Box fontSize="3xl" fontWeight="semibold" mt="2">
+      <Box fontSize="2xl" fontWeight="semibold" mt="2">
         {content}
       </Box>
     </Card>


### PR DESCRIPTION
## Summary
- reduce font size of numbers shown in Active Users and Data Usage sections

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_b_684a1b0ef024832dac710c7bfc1dcb6b