### PR TITLE
Fix menu focus highlight

### DIFF
--- a/app/dashboard/src/components/Header.tsx
+++ b/app/dashboard/src/components/Header.tsx
@@ -4,13 +4,13 @@ import {
   chakra,
   HStack,
   IconButton,
-  Menu,
   MenuButton,
   MenuItem,
   MenuList,
   Text,
   useColorMode,
 } from "@chakra-ui/react";
+import { NoAutoHighlightMenu } from "./NoAutoHighlightMenu";
 import {
   ArrowLeftOnRectangleIcon,
   Bars3Icon,
@@ -132,7 +132,7 @@ export const Header: FC<HeaderProps> = ({ actions }) => {
       )} */}
       <Box overflow="auto" css={{ direction: "rtl" }}>
         <HStack alignItems="center">
-          <Menu>
+          <NoAutoHighlightMenu>
             <MenuButton
               as={IconButton}
               size="sm"
@@ -217,7 +217,7 @@ export const Header: FC<HeaderProps> = ({ actions }) => {
                 </MenuItem>
               </Link>
             </MenuList>
-          </Menu>
+          </NoAutoHighlightMenu>
 
           {isSudo() && (
             <IconButton

--- a/app/dashboard/src/components/Language.tsx
+++ b/app/dashboard/src/components/Language.tsx
@@ -1,12 +1,12 @@
 import {
   chakra,
   IconButton,
-  Menu,
   MenuButton,
   MenuItemOption,
   MenuList,
   MenuOptionGroup,
 } from "@chakra-ui/react";
+import { NoAutoHighlightMenu } from "./NoAutoHighlightMenu";
 import { LanguageIcon } from "@heroicons/react/24/outline";
 import { FC, ReactNode } from "react";
 import { useTranslation } from "react-i18next";
@@ -30,7 +30,7 @@ export const Language: FC<HeaderProps> = ({ actions }) => {
   };
 
   return (
-    <Menu placement="bottom-end">
+    <NoAutoHighlightMenu placement="bottom-end">
       <MenuButton
         as={IconButton}
         size="sm"
@@ -58,6 +58,6 @@ export const Language: FC<HeaderProps> = ({ actions }) => {
           </MenuItemOption>
         </MenuOptionGroup>
       </MenuList>
-    </Menu>
+    </NoAutoHighlightMenu>
   );
 };

--- a/app/dashboard/src/components/NoAutoHighlightMenu.tsx
+++ b/app/dashboard/src/components/NoAutoHighlightMenu.tsx
@@ -1,0 +1,19 @@
+import { Menu, MenuProps, useMenuContext } from "@chakra-ui/react";
+import { FC, useEffect } from "react";
+
+const RemoveInitialHighlight: FC = () => {
+  const api = useMenuContext();
+  useEffect(() => {
+    if (api.open) {
+      requestAnimationFrame(() => api.setHighlightedValue(""));
+    }
+  }, [api.open]);
+  return null;
+};
+
+export const NoAutoHighlightMenu: FC<MenuProps> = ({ children, ...props }) => (
+  <Menu {...props}>
+    <RemoveInitialHighlight />
+    {children}
+  </Menu>
+);


### PR DESCRIPTION
## Summary
- avoid auto-highlighting the first menu item
- use new `NoAutoHighlightMenu` in Language and Header components

## Testing
- `npm run build` *(fails: Module '@chakra-ui/react' missing exports)*

------
https://chatgpt.com/codex/tasks/task_b_684a36f65cd0832d95b12b452b73f784