### PR TITLE
Fix menu selection highlight

### DIFF
--- a/app/dashboard/src/components/Header.tsx
+++ b/app/dashboard/src/components/Header.tsx
@@ -132,7 +132,7 @@ export const Header: FC<HeaderProps> = ({ actions }) => {
       )} */}
       <Box overflow="auto" css={{ direction: "rtl" }}>
         <HStack alignItems="center">
-          <Menu>
+          <Menu autoSelect={false}>
             <MenuButton
               as={IconButton}
               size="sm"

--- a/app/dashboard/src/components/Language.tsx
+++ b/app/dashboard/src/components/Language.tsx
@@ -29,7 +29,7 @@ export const Language: FC<HeaderProps> = ({ actions }) => {
   };
 
   return (
-    <Menu placement="bottom-end">
+    <Menu placement="bottom-end" autoSelect={false}>
       <MenuButton
         as={IconButton}
         size="sm"


### PR DESCRIPTION
## Summary
- prevent Chakra menus from automatically selecting the first item

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_684a39545384832db717bd6b039cb71b