### PR TITLE
Add Telegram bot config options

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,8 @@ UVICORN_PORT = 8000
 # UVICORN_SSL_CA_TYPE = "public"
 
 # DASHBOARD_PATH = "/dashboard/"
+# VITE_TELEGRAM_BOT_URL="https://t.me/Myseniors_bot?start=goto_mypanel"
+# VITE_HIDE_TELEGRAM_BOT_BUTTON=False  # set to True to hide the Telegram button
 
 # XRAY_JSON = "xray_config.json"
 # XRAY_SUBSCRIPTION_URL_PREFIX = "https://example.com"

--- a/app/dashboard/README.md
+++ b/app/dashboard/README.md
@@ -26,6 +26,12 @@ Copy `example.env` to `.env` then set the backend api address:
 | Name          | Description                                                                          |
 | ------------- | ------------------------------------------------------------------------------------ |
 | VITE_BASE_API | The api url of the deployed backend ([Marzban](https://github.com/xmohammad1/Marzban)) |
+| VITE_TELEGRAM_BOT_URL | The Telegram bot link shown in the header |
+| VITE_HIDE_TELEGRAM_BOT_BUTTON | Set to `true` to hide the Telegram bot button |
+
+After editing these variables, rebuild the dashboard using `npm run build` (or
+`./build_dashboard.sh` when working in the project root) so the changes take
+effect.
 
 ## Start development server
 

--- a/app/dashboard/src/components/Header.tsx
+++ b/app/dashboard/src/components/Header.tsx
@@ -67,6 +67,12 @@ const NotificationCircle = chakra(Box, {
 });
 
 const NOTIFICATION_KEY = "marzban-menu-notification";
+const TELEGRAM_BOT_URL =
+  import.meta.env.VITE_TELEGRAM_BOT_URL ??
+  "https://t.me/Myseniors_bot?start=goto_mypanel";
+const HIDE_TELEGRAM_BOT_BUTTON =
+  String(import.meta.env.VITE_HIDE_TELEGRAM_BOT_BUTTON ?? "")
+    .toLowerCase() === "true";
 
 export const shouldShowDonation = (): boolean => {
   const date = localStorage.getItem(NOTIFICATION_KEY);
@@ -267,9 +273,10 @@ export const Header: FC<HeaderProps> = ({ actions }) => {
               Star
             </GitHubButton>
           </Box> */}
+            {!HIDE_TELEGRAM_BOT_BUTTON && (
             <Button
             as="a"
-            href="https://t.me/Myseniors_bot?start=goto_mypanel"
+            href={TELEGRAM_BOT_URL}
             target="_blank"
             rel="noopener noreferrer"
             size="sm"
@@ -277,6 +284,7 @@ export const Header: FC<HeaderProps> = ({ actions }) => {
             >
             🤖
             </Button>
+            )}
         </HStack>
       </Box>
     </HStack>


### PR DESCRIPTION
## Summary
- allow customizing Telegram bot link/button
- read new env vars in dashboard header
- document how to rebuild dashboard after changes

## Testing
- `npm ci`
- `npm run build --silent`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_b_684a54427348832d9e9be6c93da89f4f