### PR TITLE
Handle node reconnection without Xray restart

### DIFF
--- a/app/xray/node.py
+++ b/app/xray/node.py
@@ -13,14 +13,18 @@ import requests
 import rpyc
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.poolmanager import PoolManager
-from websocket import WebSocketConnectionClosedException, WebSocketTimeoutException, create_connection
+from websocket import (
+    WebSocketConnectionClosedException,
+    WebSocketTimeoutException,
+    create_connection,
+)
 
 from app.xray.config import XRayConfig
 from xray_api import XRay as XRayAPI
 
 
 def string_to_temp_file(content: str):
-    file = tempfile.NamedTemporaryFile(mode='w+t')
+    file = tempfile.NamedTemporaryFile(mode="w+t")
     file.write(content)
     file.flush()
     return file
@@ -28,10 +32,9 @@ def string_to_temp_file(content: str):
 
 class SANIgnoringAdaptor(HTTPAdapter):
     def init_poolmanager(self, connections, maxsize, block=False):
-        self.poolmanager = PoolManager(num_pools=connections,
-                                       maxsize=maxsize,
-                                       block=block,
-                                       assert_hostname=False)
+        self.poolmanager = PoolManager(
+            num_pools=connections, maxsize=maxsize, block=block, assert_hostname=False
+        )
 
 
 class NodeAPIError(Exception):
@@ -41,13 +44,15 @@ class NodeAPIError(Exception):
 
 
 class ReSTXRayNode:
-    def __init__(self,
-                 address: str,
-                 port: int,
-                 api_port: int,
-                 ssl_key: str,
-                 ssl_cert: str,
-                 usage_coefficient: float = 1):
+    def __init__(
+        self,
+        address: str,
+        port: int,
+        api_port: int,
+        ssl_key: str,
+        ssl_cert: str,
+        usage_coefficient: float = 1,
+    ):
 
         self.address = address
         self.port = port
@@ -60,7 +65,7 @@ class ReSTXRayNode:
         self._certfile = string_to_temp_file(ssl_cert)
 
         self.session = requests.Session()
-        self.session.mount('https://', SANIgnoringAdaptor())
+        self.session.mount("https://", SANIgnoringAdaptor())
         self.session.cert = (self._certfile.name, self._keyfile.name)
 
         self._session_id = None
@@ -69,7 +74,9 @@ class ReSTXRayNode:
         self._ssl_context = ssl.create_default_context()
         self._ssl_context.check_hostname = False
         self._ssl_context.verify_mode = ssl.CERT_NONE
-        self._ssl_context.load_cert_chain(certfile=self.session.cert[0], keyfile=self.session.cert[1])
+        self._ssl_context.load_cert_chain(
+            certfile=self.session.cert[0], keyfile=self.session.cert[1]
+        )
         self._logs_ws_url = f"wss://{self.address.strip('/')}:{self.port}/logs"
         self._logs_queues = []
         self._logs_bg_thread = threading.Thread(target=self._bg_fetch_logs, daemon=True)
@@ -84,25 +91,26 @@ class ReSTXRayNode:
             certificates = tlsSettings.get("certificates") or []
             for certificate in certificates:
                 if certificate.get("certificateFile"):
-                    with open(certificate['certificateFile']) as file:
-                        certificate['certificate'] = [
+                    with open(certificate["certificateFile"]) as file:
+                        certificate["certificate"] = [
                             line.strip() for line in file.readlines()
                         ]
-                        del certificate['certificateFile']
+                        del certificate["certificateFile"]
 
                 if certificate.get("keyFile"):
-                    with open(certificate['keyFile']) as file:
-                        certificate['key'] = [
-                            line.strip() for line in file.readlines()
-                        ]
-                        del certificate['keyFile']
+                    with open(certificate["keyFile"]) as file:
+                        certificate["key"] = [line.strip() for line in file.readlines()]
+                        del certificate["keyFile"]
 
         return config
 
     def make_request(self, path: str, timeout: int, **params):
         try:
-            res = self.session.post(self._rest_api_url + path, timeout=timeout,
-                                    json={"session_id": self._session_id, **params})
+            res = self.session.post(
+                self._rest_api_url + path,
+                timeout=timeout,
+                json={"session_id": self._session_id, **params},
+            )
             data = res.json()
         except Exception as e:
             exc = NodeAPIError(0, str(e))
@@ -111,7 +119,7 @@ class ReSTXRayNode:
         if res.status_code == 200:
             return data
         else:
-            exc = NodeAPIError(res.status_code, data['detail'])
+            exc = NodeAPIError(res.status_code, data["detail"])
             raise exc
 
     @property
@@ -127,41 +135,82 @@ class ReSTXRayNode:
     @property
     def started(self):
         res = self.make_request("/", timeout=3)
-        return res.get('started', False)
+        return res.get("started", False)
 
     @property
     def api(self):
         if not self._session_id:
             raise ConnectionError("Node is not connected")
 
-        if not self._api:
-            if self._started is True:
+        if not self._api or not self._started:
+            try:
+                self._started = self.started
+            except NodeAPIError:
+                self._started = False
+
+            if self._started:
                 self._api = XRayAPI(
                     address=self.address,
                     port=self.api_port,
                     ssl_cert=self._node_cert.encode(),
-                    ssl_target_name="Gozargah"
+                    ssl_target_name="Gozargah",
                 )
+                try:
+                    grpc.channel_ready_future(self._api._channel).result(timeout=5)
+                except grpc.FutureTimeoutError:
+                    raise ConnectionError("Failed to connect to node's API")
             else:
                 raise ConnectionError("Node is not started")
 
         return self._api
 
     def connect(self):
+        if self._session_id:
+            self.disconnect()
+
         self._node_cert = ssl.get_server_certificate((self.address, self.port))
         self._node_certfile = string_to_temp_file(self._node_cert)
         self.session.verify = self._node_certfile.name
 
         res = self.make_request("/connect", timeout=3)
-        self._session_id = res['session_id']
+        self._session_id = res["session_id"]
 
     def disconnect(self):
-        self.make_request("/disconnect", timeout=3)
+        if not self._session_id:
+            return
+
+        try:
+            self.make_request("/disconnect", timeout=3)
+        except NodeAPIError:
+            pass
         self._session_id = None
+        self._api = None
+
+    def reconnect(self):
+        """Reconnect to a previously connected node without restarting Xray."""
+        self.connect()
+        try:
+            self._started = self.started
+        except NodeAPIError:
+            self._started = False
+
+        if self._started:
+            self._api = XRayAPI(
+                address=self.address,
+                port=self.api_port,
+                ssl_cert=self._node_cert.encode(),
+                ssl_target_name="Gozargah",
+            )
+            try:
+                grpc.channel_ready_future(self._api._channel).result(timeout=5)
+            except grpc.FutureTimeoutError:
+                raise ConnectionError("Failed to connect to node's API")
+        else:
+            self._api = None
 
     def get_version(self):
         res = self.make_request("/", timeout=3)
-        return res.get('core_version')
+        return res.get("core_version")
 
     def start(self, config: XRayConfig):
         if not self.connected:
@@ -173,7 +222,7 @@ class ReSTXRayNode:
         try:
             res = self.make_request("/start", timeout=10, config=json_config)
         except NodeAPIError as exc:
-            if exc.detail == 'Xray is started already':
+            if exc.detail == "Xray is started already":
                 return self.restart(config)
             else:
                 raise exc
@@ -184,13 +233,13 @@ class ReSTXRayNode:
             address=self.address,
             port=self.api_port,
             ssl_cert=self._node_cert.encode(),
-            ssl_target_name="Gozargah"
+            ssl_target_name="Gozargah",
         )
 
         try:
             grpc.channel_ready_future(self._api._channel).result(timeout=5)
         except grpc.FutureTimeoutError:
-            raise ConnectionError('Failed to connect to node\'s API')
+            raise ConnectionError("Failed to connect to node's API")
 
         return res
 
@@ -198,7 +247,7 @@ class ReSTXRayNode:
         if not self.connected:
             self.connect()
 
-        self.make_request('/stop', timeout=5)
+        self.make_request("/stop", timeout=5)
         self._api = None
         self._started = False
 
@@ -217,22 +266,26 @@ class ReSTXRayNode:
             address=self.address,
             port=self.api_port,
             ssl_cert=self._node_cert.encode(),
-            ssl_target_name="Gozargah"
+            ssl_target_name="Gozargah",
         )
 
         try:
             grpc.channel_ready_future(self._api._channel).result(timeout=5)
         except grpc.FutureTimeoutError:
-            raise ConnectionError('Failed to connect to node\'s API')
+            raise ConnectionError("Failed to connect to node's API")
 
         return res
 
     def _bg_fetch_logs(self):
         while self._logs_queues:
             try:
-                websocket_url = f"{self._logs_ws_url}?session_id={self._session_id}&interval=0.7"
+                websocket_url = (
+                    f"{self._logs_ws_url}?session_id={self._session_id}&interval=0.7"
+                )
                 self._ssl_context.load_verify_locations(self.session.verify)
-                ws = create_connection(websocket_url, sslopt={"context": self._ssl_context}, timeout=2)
+                ws = create_connection(
+                    websocket_url, sslopt={"context": self._ssl_context}, timeout=2
+                )
                 while self._logs_queues:
                     try:
                         logs = ws.recv()
@@ -258,7 +311,9 @@ class ReSTXRayNode:
                 try:
                     self._logs_bg_thread.start()
                 except RuntimeError:
-                    self._logs_bg_thread = threading.Thread(target=self._bg_fetch_logs, daemon=True)
+                    self._logs_bg_thread = threading.Thread(
+                        target=self._bg_fetch_logs, daemon=True
+                    )
                     self._logs_bg_thread.start()
 
             yield buf
@@ -272,18 +327,22 @@ class ReSTXRayNode:
 
 
 class RPyCXRayNode:
-    def __init__(self,
-                 address: str,
-                 port: int,
-                 api_port: int,
-                 ssl_key: str,
-                 ssl_cert: str,
-                 usage_coefficient: float = 1):
+    def __init__(
+        self,
+        address: str,
+        port: int,
+        api_port: int,
+        ssl_key: str,
+        ssl_cert: str,
+        usage_coefficient: float = 1,
+    ):
 
         class Service(rpyc.Service):
-            def __init__(self,
-                         on_start_funcs: List[callable] = [],
-                         on_stop_funcs: List[callable] = []):
+            def __init__(
+                self,
+                on_start_funcs: List[callable] = [],
+                on_stop_funcs: List[callable] = [],
+            ):
                 self.on_start_funcs = on_start_funcs
                 self.on_stop_funcs = on_stop_funcs
 
@@ -329,6 +388,28 @@ class RPyCXRayNode:
         except AttributeError:
             pass
 
+    def reconnect(self):
+        """Reconnect to an existing node session without restarting Xray."""
+        self.connect()
+        try:
+            self.started = bool(self.remote.fetch_xray_version())
+        except Exception:
+            self.started = False
+
+        if self.started:
+            self._api = XRayAPI(
+                address=self.address,
+                port=self.api_port,
+                ssl_cert=self._node_cert.encode(),
+                ssl_target_name="Gozargah",
+            )
+            try:
+                grpc.channel_ready_future(self._api._channel).result(timeout=5)
+            except grpc.FutureTimeoutError:
+                raise ConnectionError("Failed to connect to node's API")
+        else:
+            self._api = None
+
     def connect(self):
         self.disconnect()
 
@@ -337,13 +418,15 @@ class RPyCXRayNode:
             tries += 1
             self._node_cert = ssl.get_server_certificate((self.address, self.port))
             self._node_certfile = string_to_temp_file(self._node_cert)
-            conn = rpyc.ssl_connect(self.address,
-                                    self.port,
-                                    service=self._service,
-                                    keyfile=self._keyfile.name,
-                                    certfile=self._certfile.name,
-                                    ca_certs=self._node_certfile.name,
-                                    keepalive=True)
+            conn = rpyc.ssl_connect(
+                self.address,
+                self.port,
+                service=self._service,
+                keyfile=self._keyfile.name,
+                certfile=self._certfile.name,
+                ca_certs=self._node_certfile.name,
+                keepalive=True,
+            )
             try:
                 conn.ping()
                 self.connection = conn
@@ -357,7 +440,7 @@ class RPyCXRayNode:
     def connected(self):
         try:
             self.connection.ping()
-            return (not self.connection.closed)
+            return not self.connection.closed
         except (AttributeError, EOFError, TimeoutError):
             self.disconnect()
             return False
@@ -373,8 +456,25 @@ class RPyCXRayNode:
         if not self.connected:
             raise ConnectionError("Node is not connected")
 
-        if not self.started:
-            raise ConnectionError("Node is not started")
+        if not self.started or not self._api:
+            try:
+                self.started = bool(self.remote.fetch_xray_version())
+            except Exception:
+                self.started = False
+
+            if self.started:
+                self._api = XRayAPI(
+                    address=self.address,
+                    port=self.api_port,
+                    ssl_cert=self._node_cert.encode(),
+                    ssl_target_name="Gozargah",
+                )
+                try:
+                    grpc.channel_ready_future(self._api._channel).result(timeout=5)
+                except grpc.FutureTimeoutError:
+                    raise ConnectionError("Failed to connect to node's API")
+            else:
+                raise ConnectionError("Node is not started")
 
         return self._api
 
@@ -388,18 +488,16 @@ class RPyCXRayNode:
             certificates = tlsSettings.get("certificates") or []
             for certificate in certificates:
                 if certificate.get("certificateFile"):
-                    with open(certificate['certificateFile']) as file:
-                        certificate['certificate'] = [
+                    with open(certificate["certificateFile"]) as file:
+                        certificate["certificate"] = [
                             line.strip() for line in file.readlines()
                         ]
-                        del certificate['certificateFile']
+                        del certificate["certificateFile"]
 
                 if certificate.get("keyFile"):
-                    with open(certificate['keyFile']) as file:
-                        certificate['key'] = [
-                            line.strip() for line in file.readlines()
-                        ]
-                        del certificate['keyFile']
+                    with open(certificate["keyFile"]) as file:
+                        certificate["key"] = [line.strip() for line in file.readlines()]
+                        del certificate["keyFile"]
 
         return config
 
@@ -414,7 +512,7 @@ class RPyCXRayNode:
             address=self.address,
             port=self.api_port,
             ssl_cert=self._node_cert.encode(),
-            ssl_target_name="Gozargah"
+            ssl_target_name="Gozargah",
         )
         try:
             grpc.channel_ready_future(self._api._channel).result(timeout=5)
@@ -422,19 +520,19 @@ class RPyCXRayNode:
 
             start_time = time.time()
             end_time = start_time + 3  # check logs for 3 seconds
-            last_log = ''
+            last_log = ""
             with self.get_logs() as logs:
                 while time.time() < end_time:
                     if logs:
-                        last_log = logs[-1].strip().split('\n')[-1]
+                        last_log = logs[-1].strip().split("\n")[-1]
                     time.sleep(0.1)
 
             self.disconnect()
 
-            if re.search(r'[Ff]ailed', last_log):
+            if re.search(r"[Ff]ailed", last_log):
                 raise RuntimeError(last_log)
 
-            raise ConnectionError('Failed to connect to node\'s API')
+            raise ConnectionError("Failed to connect to node's API")
 
     def stop(self):
         self.remote.stop()
@@ -494,20 +592,22 @@ class RPyCXRayNode:
 
 
 class XRayNode:
-    def __new__(self,
-                address: str,
-                port: int,
-                api_port: int,
-                ssl_key: str,
-                ssl_cert: str,
-                usage_coefficient: float = 1):
+    def __new__(
+        self,
+        address: str,
+        port: int,
+        api_port: int,
+        ssl_key: str,
+        ssl_cert: str,
+        usage_coefficient: float = 1,
+    ):
 
         # trying to detect what's the server of node
         try:
             s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             s.settimeout(1)
             s.connect((address, port))
-            s.send(b'HEAD / HTTP/1.0\r\n\r\n')
+            s.send(b"HEAD / HTTP/1.0\r\n\r\n")
             s.recv(1024)
             s.close()
             # it might be uvicorn
@@ -517,7 +617,7 @@ class XRayNode:
                 api_port=api_port,
                 ssl_key=ssl_key,
                 ssl_cert=ssl_cert,
-                usage_coefficient=usage_coefficient
+                usage_coefficient=usage_coefficient,
             )
         except Exception:
             # if might be rpyc
@@ -527,5 +627,5 @@ class XRayNode:
                 api_port=api_port,
                 ssl_key=ssl_key,
                 ssl_cert=ssl_cert,
-                usage_coefficient=usage_coefficient
+                usage_coefficient=usage_coefficient,
             )

--- a/app/xray/operations.py
+++ b/app/xray/operations.py
@@ -20,12 +20,10 @@ if TYPE_CHECKING:
 @lru_cache(maxsize=None)
 def get_tls():
     from app.db import GetDB, get_tls_certificate
+
     with GetDB() as db:
         tls = get_tls_certificate(db)
-        return {
-            "key": tls.key,
-            "certificate": tls.certificate
-        }
+        return {"key": tls.key, "certificate": tls.certificate}
 
 
 @threaded_function
@@ -71,16 +69,13 @@ def add_user(dbuser: "DBUser"):
             account = proxy_type.account_model(email=email, **proxy_settings)
 
             # XTLS currently only supports transmission methods of TCP and mKCP
-            if getattr(account, 'flow', None) and (
-                inbound.get('network', 'tcp') not in ('tcp', 'kcp')
-                or
-                (
-                    inbound.get('network', 'tcp') in ('tcp', 'kcp')
-                    and
-                    inbound.get('tls') not in ('tls', 'reality')
+            if getattr(account, "flow", None) and (
+                inbound.get("network", "tcp") not in ("tcp", "kcp")
+                or (
+                    inbound.get("network", "tcp") in ("tcp", "kcp")
+                    and inbound.get("tls") not in ("tls", "reality")
                 )
-                or
-                inbound.get('header_type') == 'http'
+                or inbound.get("header_type") == "http"
             ):
                 account.flow = XTLSFlows.NONE
 
@@ -117,16 +112,13 @@ def update_user(dbuser: "DBUser"):
             account = proxy_type.account_model(email=email, **proxy_settings)
 
             # XTLS currently only supports transmission methods of TCP and mKCP
-            if getattr(account, 'flow', None) and (
-                inbound.get('network', 'tcp') not in ('tcp', 'kcp')
-                or
-                (
-                    inbound.get('network', 'tcp') in ('tcp', 'kcp')
-                    and
-                    inbound.get('tls') not in ('tls', 'reality')
+            if getattr(account, "flow", None) and (
+                inbound.get("network", "tcp") not in ("tcp", "kcp")
+                or (
+                    inbound.get("network", "tcp") in ("tcp", "kcp")
+                    and inbound.get("tls") not in ("tls", "reality")
                 )
-                or
-                inbound.get('header_type') == 'http'
+                or inbound.get("header_type") == "http"
             ):
                 account.flow = XTLSFlows.NONE
 
@@ -162,17 +154,21 @@ def add_node(dbnode: "DBNode"):
     remove_node(dbnode.id)
 
     tls = get_tls()
-    xray.nodes[dbnode.id] = XRayNode(address=dbnode.address,
-                                     port=dbnode.port,
-                                     api_port=dbnode.api_port,
-                                     ssl_key=tls['key'],
-                                     ssl_cert=tls['certificate'],
-                                     usage_coefficient=dbnode.usage_coefficient)
+    xray.nodes[dbnode.id] = XRayNode(
+        address=dbnode.address,
+        port=dbnode.port,
+        api_port=dbnode.api_port,
+        ssl_key=tls["key"],
+        ssl_cert=tls["certificate"],
+        usage_coefficient=dbnode.usage_coefficient,
+    )
 
     return xray.nodes[dbnode.id]
 
 
-def _change_node_status(node_id: int, status: NodeStatus, message: str = None, version: str = None):
+def _change_node_status(
+    node_id: int, status: NodeStatus, message: str = None, version: str = None
+):
     with GetDB() as db:
         try:
             dbnode = crud.get_node_by_id(db, node_id)
@@ -207,27 +203,34 @@ def connect_node(node_id, config=None):
 
     try:
         node = xray.nodes[dbnode.id]
-        assert node.connected
-    except (KeyError, AssertionError):
+    except KeyError:
         node = xray.operations.add_node(dbnode)
+
+    if not node.connected:
+        try:
+            node.reconnect()
+        except Exception:
+            node = xray.operations.add_node(dbnode)
+            node.connect()
 
     try:
         _connecting_nodes[node_id] = True
 
         _change_node_status(node_id, NodeStatus.connecting)
-        logger.info(f"Connecting to \"{dbnode.name}\" node")
+        logger.info(f'Connecting to "{dbnode.name}" node')
 
-        if config is None:
-            config = xray.config.include_db_users()
+        if not node.started:
+            if config is None:
+                config = xray.config.include_db_users()
 
-        node.start(config)
+            node.start(config)
         version = node.get_version()
         _change_node_status(node_id, NodeStatus.connected, version=version)
-        logger.info(f"Connected to \"{dbnode.name}\" node, xray run on v{version}")
+        logger.info(f'Connected to "{dbnode.name}" node, xray run on v{version}')
 
     except Exception as e:
         _change_node_status(node_id, NodeStatus.error, message=str(e))
-        logger.info(f"Unable to connect to \"{dbnode.name}\" node")
+        logger.info(f'Unable to connect to "{dbnode.name}" node')
 
     finally:
         try:
@@ -253,13 +256,13 @@ def restart_node(node_id, config=None):
         return connect_node(node_id, config)
 
     try:
-        logger.info(f"Restarting Xray core of \"{dbnode.name}\" node")
+        logger.info(f'Restarting Xray core of "{dbnode.name}" node')
 
         if config is None:
             config = xray.config.include_db_users()
 
         node.restart(config)
-        logger.info(f"Xray core of \"{dbnode.name}\" node restarted")
+        logger.info(f'Xray core of "{dbnode.name}" node restarted')
     except Exception as e:
         _change_node_status(node_id, NodeStatus.error, message=str(e))
         logger.info(f"Unable to restart node {node_id}")


### PR DESCRIPTION
## Summary
- add `reconnect` to REST and RPyC node classes
- rework `connect_node` to reuse existing nodes and avoid restarting Xray when reconnecting
- allow API property to establish connection if the node is already running
- format modified files with Black
- prevent unnecessary disconnects during REST node reconnection

## Testing
- `python -m py_compile app/xray/node.py app/xray/operations.py`
- `black --check app/xray/node.py app/xray/operations.py`


------
https://chatgpt.com/codex/tasks/task_b_684b23eb0a00832d82753edca9c38b97