### PR TITLE
Fix status filter reset

### DIFF
--- a/app/dashboard/src/components/UsersTable.tsx
+++ b/app/dashboard/src/components/UsersTable.tsx
@@ -343,7 +343,7 @@ export const UsersTable: FC<UsersTableProps> = (props) => {
                     {filters.status ? ": " + filters.status : ""}
                   </Text>
                   <Select
-                    value={filters.sort}
+                    value={filters.status ?? ""}
                     fontSize="xs"
                     fontWeight="extrabold"
                     textTransform="uppercase"
@@ -615,7 +615,7 @@ export const UsersTable: FC<UsersTableProps> = (props) => {
                   _focusVisible={{
                     border: "0 !important",
                   }}
-                  value={filters.sort}
+                  value={filters.status ?? ""}
                   onChange={handleStatusFilter}
                 >
                   <option></option>


### PR DESCRIPTION
## Summary
- fix value prop for status filter dropdown so it can clear status filters

## Testing
- `npm run build` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_b_684b4f4d9e78832dbc44db0be0d540dc