### PR TITLE
Improve bulk deletion performance

### DIFF
--- a/app/dashboard/src/contexts/DashboardContext.tsx
+++ b/app/dashboard/src/contexts/DashboardContext.tsx
@@ -183,9 +183,7 @@ export const useDashboard = create(
       });
     },
     deleteUsers: async (users: User[]) => {
-      for (const user of users) {
-        await get().deleteUser(user);
-      }
+      await Promise.all(users.map((user) => get().deleteUser(user)));
     },
     createUser: async (body: UserCreate) => {
       await fetch(`/user`, { method: "POST", body });


### PR DESCRIPTION
## Summary
- optimize selected user deletions by sending requests concurrently

## Testing
- `npm run build` in `app/dashboard`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_684b54bc7d30832d8322e46f0e075d1a