### PR TITLE
Improve bulk user deletion

### DIFF
--- a/app/dashboard/src/contexts/DashboardContext.tsx
+++ b/app/dashboard/src/contexts/DashboardContext.tsx
@@ -183,9 +183,10 @@ export const useDashboard = create(
       });
     },
     deleteUsers: async (users: User[]) => {
-      for (const user of users) {
-        await get().deleteUser(user);
-      }
+      const usernames = users.map((u) => u.username);
+      await fetch(`/users`, { method: "DELETE", body: { usernames } });
+      get().refetchUsers();
+      queryClient.invalidateQueries(StatisticsQueryKey);
     },
     createUser: async (body: UserCreate) => {
       await fetch(`/user`, { method: "POST", body });

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -364,3 +364,8 @@ class UserUsagesResponse(BaseModel):
 
 class UsersUsagesResponse(BaseModel):
     usages: List[UserUsageResponse]
+
+
+class DeleteUsersRequest(BaseModel):
+    usernames: List[str]
+

--- a/app/routers/user.py
+++ b/app/routers/user.py
@@ -16,6 +16,7 @@ from app.models.user import (
     UserStatus,
     UsersUsagesResponse,
     UserUsagesResponse,
+    DeleteUsersRequest,
 )
 from app.utils import report, responses
 
@@ -154,6 +155,38 @@ def remove_user(
 
     logger.info(f'User "{dbuser.username}" deleted')
     return {"detail": "User successfully deleted"}
+
+
+@router.delete("/users", response_model=List[str], responses={403: responses._403, 404: responses._404})
+def remove_users(
+    body: DeleteUsersRequest,
+    bg: BackgroundTasks,
+    db: Session = Depends(get_db),
+    admin: Admin = Depends(Admin.get_current),
+):
+    """Remove multiple users"""
+    dbadmin = crud.get_admin(db, admin.username)
+    dbusers = crud.get_users(
+        db=db,
+        usernames=body.usernames,
+        admin=dbadmin if not admin.is_sudo else None,
+    )
+
+    if not dbusers:
+        raise HTTPException(status_code=404, detail="No users found")
+
+    crud.remove_users(db, dbusers)
+
+    for dbuser in dbusers:
+        logger.info(f'User "{dbuser.username}" deleted')
+        bg.add_task(
+            report.user_deleted,
+            username=dbuser.username,
+            user_admin=Admin.model_validate(dbuser.admin),
+            by=admin,
+        )
+
+    return [u.username for u in dbusers]
 
 
 @router.post("/user/{username}/reset", response_model=UserResponse, responses={403: responses._403, 404: responses._404})


### PR DESCRIPTION
## Summary
- add DeleteUsersRequest model for removing multiple users
- support deleting multiple users in one API call
- speed up dashboard bulk deletion by calling new endpoint

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_684b54987d94832da9661317ecfc4b04