### PR TITLE
Enable pushing PR Docker images

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -35,11 +35,17 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Build Docker image
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push Docker image
         uses: docker/build-push-action@v3
         with:
           context: .
           platforms: linux/amd64
-          push: false
-          load: true
+          push: true
+          tags: xmohammad1/marzban:pr-${{ github.event.pull_request.number }}
 


### PR DESCRIPTION
## Summary
- update PR workflow to login to Docker Hub and push image tagged with PR number

## Testing
- `pre-commit` *(fails: no pre-commit config)*

------
https://chatgpt.com/codex/tasks/task_b_684b5e83430c832db5215389008fd8ea