### PR TITLE
Improve bulk user creation

### DIFF
--- a/app/dashboard/src/components/UserDialog.tsx
+++ b/app/dashboard/src/components/UserDialog.tsx
@@ -62,6 +62,11 @@ import { UsageFilter, createUsageConfig } from "./UsageFilter";
 import { ReloadIcon } from "./Filters";
 import classNames from "classnames";
 
+const getNumberAtEnd = (username: string): string | null => {
+  const match = username.match(/(\d+)$/);
+  return match ? match[1] : null;
+};
+
 const AddUserIcon = chakra(UserPlusIcon, {
   baseStyle: {
     w: 5,
@@ -340,12 +345,18 @@ export const UserDialog: FC<UserDialogProps> = () => {
     try {
       const count = values.bulk_count || 1;
       if (!isEditing && count > 1) {
+        const numberAtEnd = getNumberAtEnd(values.username);
         for (let i = 0; i < count; i++) {
-          const username = `${values.username}_${i + 1}`;
-          // Ensure each user is created sequentially
+          let username = values.username;
+          if (numberAtEnd) {
+            username = username.replace(
+              numberAtEnd,
+              String(Number(numberAtEnd) + i)
+            );
+          } else if (i > 0) {
+            username = `${values.username}_${i + 1}`;
+          }
           await createUser({ ...body, username });
-          // Add a small delay between each creation
-          await new Promise((resolve) => setTimeout(resolve, 5));
         }
       } else {
         await create();

--- a/app/dashboard/src/components/UserDialog.tsx
+++ b/app/dashboard/src/components/UserDialog.tsx
@@ -70,6 +70,23 @@ const getNumberAtEnd = (username: string): string | null => {
   return match ? match[1] : null;
 };
 
+const escapeRegExp = (value: string) =>
+  value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+const getNextIndex = (base: string): number => {
+  const users = useDashboard.getState().users.users;
+  const regex = new RegExp(`^${escapeRegExp(base)}(\\d+)$`);
+  let max = 0;
+  for (const { username } of users) {
+    const match = username.match(regex);
+    if (match) {
+      const num = Number(match[1]);
+      if (num > max) max = num;
+    }
+  }
+  return max + 1;
+};
+
 const AddUserIcon = chakra(UserPlusIcon, {
   baseStyle: {
     w: 5,
@@ -348,17 +365,16 @@ export const UserDialog: FC<UserDialogProps> = () => {
     try {
       const count = values.bulk_count || 1;
       if (!isEditing && count > 1) {
-        const numberAtEnd = getNumberAtEnd(values.username);
+        const trailing = getNumberAtEnd(values.username);
+        const base = trailing
+          ? values.username.slice(0, -trailing.length)
+          : `${values.username}_`;
+        let nextIndex = getNextIndex(base);
+        if (trailing) {
+          nextIndex = Math.max(nextIndex, Number(trailing));
+        }
         for (let i = 0; i < count; i++) {
-          let username: string;
-          if (numberAtEnd) {
-            username = values.username.replace(
-              numberAtEnd,
-              String(Number(numberAtEnd) + i)
-            );
-          } else {
-            username = `${values.username}_${i + 1}`;
-          }
+          const username = `${base}${nextIndex + i}`;
           await fetch(`/user`, { method: "POST", body: { ...body, username } });
           toast({
             title: t("userDialog.userCreated", { username }),

--- a/app/dashboard/src/components/UserDialog.tsx
+++ b/app/dashboard/src/components/UserDialog.tsx
@@ -60,6 +60,9 @@ import { Input } from "./Input";
 import { RadioGroup } from "./RadioGroup";
 import { UsageFilter, createUsageConfig } from "./UsageFilter";
 import { ReloadIcon } from "./Filters";
+import { fetch } from "service/http";
+import { queryClient } from "utils/react-query";
+import { StatisticsQueryKey } from "./Statistics";
 import classNames from "classnames";
 
 const getNumberAtEnd = (username: string): string | null => {
@@ -347,17 +350,27 @@ export const UserDialog: FC<UserDialogProps> = () => {
       if (!isEditing && count > 1) {
         const numberAtEnd = getNumberAtEnd(values.username);
         for (let i = 0; i < count; i++) {
-          let username = values.username;
+          let username: string;
           if (numberAtEnd) {
-            username = username.replace(
+            username = values.username.replace(
               numberAtEnd,
               String(Number(numberAtEnd) + i)
             );
-          } else if (i > 0) {
+          } else {
             username = `${values.username}_${i + 1}`;
           }
-          await createUser({ ...body, username });
+          await fetch(`/user`, { method: "POST", body: { ...body, username } });
+          toast({
+            title: t("userDialog.userCreated", { username }),
+            status: "success",
+            isClosable: true,
+            position: "top",
+            duration: 3000,
+          });
         }
+        useDashboard.getState().refetchUsers();
+        queryClient.invalidateQueries(StatisticsQueryKey);
+        useDashboard.setState({ editingUser: null });
       } else {
         await create();
       }


### PR DESCRIPTION
## Summary
- add helper to detect trailing digits in usernames
- ensure sequential numbering when creating multiple users
- remove unnecessary delay in loops

## Testing
- `npm -v`
- `node -v`


------
https://chatgpt.com/codex/tasks/task_b_684b5abf62f4832da6525bcf5fa08793