### PR TITLE
Improve bulk user creation

### DIFF
--- a/app/db/crud.py
+++ b/app/db/crud.py
@@ -403,6 +403,54 @@ def create_user(db: Session, user: UserCreate, admin: Admin = None) -> User:
     return dbuser
 
 
+def create_users_bulk(db: Session, users: List[UserCreate], admin: Admin = None) -> List[User]:
+    """Create multiple users in a single transaction."""
+    dbusers: List[User] = []
+    for user in users:
+        excluded_inbounds_tags = user.excluded_inbounds
+        proxies = []
+        for proxy_type, settings in user.proxies.items():
+            excluded_inbounds = [
+                get_or_create_inbound(db, tag) for tag in excluded_inbounds_tags[proxy_type]
+            ]
+            proxies.append(
+                Proxy(
+                    type=proxy_type.value,
+                    settings=settings.dict(no_obj=True),
+                    excluded_inbounds=excluded_inbounds,
+                )
+            )
+
+        dbuser = User(
+            username=user.username,
+            proxies=proxies,
+            status=user.status,
+            data_limit=(user.data_limit or None),
+            expire=(user.expire or None),
+            admin=admin,
+            data_limit_reset_strategy=user.data_limit_reset_strategy,
+            note=user.note,
+            on_hold_expire_duration=(user.on_hold_expire_duration or None),
+            on_hold_timeout=(user.on_hold_timeout or None),
+            auto_delete_in_days=user.auto_delete_in_days,
+            next_plan=NextPlan(
+                data_limit=user.next_plan.data_limit,
+                expire=user.next_plan.expire,
+                add_remaining_traffic=user.next_plan.add_remaining_traffic,
+                fire_on_either=user.next_plan.fire_on_either,
+            )
+            if user.next_plan
+            else None,
+        )
+        db.add(dbuser)
+        dbusers.append(dbuser)
+
+    db.commit()
+    for u in dbusers:
+        db.refresh(u)
+    return dbusers
+
+
 def remove_user(db: Session, dbuser: User) -> User:
     """
     Removes a user from the database.

--- a/app/telegram/handlers/admin.py
+++ b/app/telegram/handlers/admin.py
@@ -1815,14 +1815,15 @@ def confirm_user_command(call: types.CallbackQuery):
         if not mem_store.get(f"{call.message.chat.id}:is_bulk", False):
             number = 1
 
+        users_to_create = []
         for i in range(number):
             proxies = copy.deepcopy(original_proxies)
             username: str = mem_store.get(f'{call.message.chat.id}:username')
             if mem_store.get(f"{call.message.chat.id}:is_bulk", False):
                 if n := get_number_at_end(username):
-                    username = username.replace(n, str(int(n)+i))
+                    username = username.replace(n, str(int(n) + i))
                 else:
-                    username += str(i+1) if i > 0 else ""
+                    username += str(i + 1)
             if user_status == 'onhold':
                 expire_days = mem_store.get(f'{call.message.chat.id}:expire_date')
                 onhold_timeout = mem_store.get(f'{call.message.chat.id}:onhold_timeout')
@@ -1854,9 +1855,15 @@ def confirm_user_command(call: types.CallbackQuery):
                         f'❌ Protocol {proxy_type} is disabled on your server',
                         show_alert=True
                     )
-            try:
-                with GetDB() as db:
-                    db_user = crud.create_user(db, new_user)
+            users_to_create.append(new_user)
+
+        try:
+            with GetDB() as db:
+                if len(users_to_create) > 1:
+                    db_users = crud.create_users_bulk(db, users_to_create)
+                else:
+                    db_users = [crud.create_user(db, users_to_create[0])]
+                for db_user in db_users:
                     proxies = db_user.proxies
                     user = UserResponse.model_validate(db_user)
                     xray.operations.add_user(db_user)
@@ -1876,14 +1883,15 @@ def confirm_user_command(call: types.CallbackQuery):
                             call.message.chat.id,
                             call.message.message_id,
                             parse_mode="HTML",
-                            reply_markup=BotKeyboard.user_menu(user_info={'status': user.status, 'username': user.username}))
-            except sqlalchemy.exc.IntegrityError:
-                db.rollback()
-                return bot.answer_callback_query(
-                    call.id,
-                    '❌ Username already exists.',
-                    show_alert=True
-                )
+                            reply_markup=BotKeyboard.user_menu(
+                                user_info={'status': user.status, 'username': user.username}))
+        except sqlalchemy.exc.IntegrityError:
+            db.rollback()
+            return bot.answer_callback_query(
+                call.id,
+                '❌ Username already exists.',
+                show_alert=True
+            )
             if TELEGRAM_LOGGER_CHANNEL_ID:
                 text = f"""\
 🆕 <b>#Created #From_Bot</b>


### PR DESCRIPTION
## Summary
- create many users in one transaction with `create_users_bulk`
- generate numeric suffixes starting from 1 for bulk mode
- use the bulk creation function in the Telegram handler

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684b661daa68832dbadffae04326473c