### PR TITLE
Add bulk user creation API and integrate in dashboard

### DIFF
--- a/app/dashboard/src/components/UserDialog.tsx
+++ b/app/dashboard/src/components/UserDialog.tsx
@@ -225,6 +225,7 @@ export const UserDialog: FC<UserDialogProps> = () => {
     fetchUserUsage,
     onEditingUser,
     createUser,
+    createBulkUsers,
     onDeletingUser,
     inbounds,
   } = useDashboard();
@@ -340,13 +341,7 @@ export const UserDialog: FC<UserDialogProps> = () => {
     try {
       const count = values.bulk_count || 1;
       if (!isEditing && count > 1) {
-        for (let i = 0; i < count; i++) {
-          const username = `${values.username}_${i + 1}`;
-          // Ensure each user is created sequentially
-          await createUser({ ...body, username });
-          // Add a small delay between each creation
-          await new Promise((resolve) => setTimeout(resolve, 5));
-        }
+        await createBulkUsers({ ...body, bulk_count: count });
       } else {
         await create();
       }

--- a/app/dashboard/src/contexts/DashboardContext.tsx
+++ b/app/dashboard/src/contexts/DashboardContext.tsx
@@ -1,6 +1,6 @@
 import { StatisticsQueryKey } from "components/Statistics";
 import { fetch } from "service/http";
-import { User, UserCreate } from "types/User";
+import { User, UserCreate, BulkUserCreate } from "types/User";
 import { queryClient } from "utils/react-query";
 import { getUsersPerPageLimitSize } from "utils/userPreferenceStorage";
 import { create } from "zustand";
@@ -65,6 +65,7 @@ type DashboardStateType = {
   onFilterChange: (filters: Partial<FilterType>) => void;
   deleteUser: (user: User) => Promise<void>;
   createUser: (user: UserCreate) => Promise<void>;
+  createBulkUsers: (users: BulkUserCreate) => Promise<void>;
   editUser: (user: UserCreate) => Promise<void>;
   fetchUserUsage: (user: User, query: FilterUsageType) => Promise<void>;
   setQRCode: (links: string[] | null) => void;
@@ -187,6 +188,12 @@ export const useDashboard = create(
     },
     createUser: async (body: UserCreate) => {
       await fetch(`/user`, { method: "POST", body });
+      set({ editingUser: null });
+      get().refetchUsers();
+      queryClient.invalidateQueries(StatisticsQueryKey);
+    },
+    createBulkUsers: async (body: BulkUserCreate) => {
+      await fetch(`/users/bulk`, { method: "POST", body });
       set({ editingUser: null });
       get().refetchUsers();
       queryClient.invalidateQueries(StatisticsQueryKey);

--- a/app/dashboard/src/types/User.ts
+++ b/app/dashboard/src/types/User.ts
@@ -65,6 +65,8 @@ export type UserCreate = Pick<
   | "note"
 >;
 
+export type BulkUserCreate = UserCreate & { bulk_count: number };
+
 export type UserApi = {
   discord_webook: string;
   is_sudo: boolean;

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -203,6 +203,11 @@ class UserCreate(User):
         return status
 
 
+class BulkUserCreate(UserCreate):
+    bulk_count: int = Field(1, ge=1, description="Number of users to create")
+
+
+
 class UserModify(User):
     status: UserStatusModify = None
     data_limit_reset_strategy: UserDataLimitResetStrategy = None

--- a/app/routers/user.py
+++ b/app/routers/user.py
@@ -10,6 +10,7 @@ from app.dependencies import get_expired_users_list, get_validated_user, validat
 from app.models.admin import Admin
 from app.models.user import (
     UserCreate,
+    BulkUserCreate,
     UserModify,
     UserResponse,
     UsersResponse,
@@ -67,6 +68,46 @@ def add_user(
     report.user_created(user=user, user_id=dbuser.id, by=admin, user_admin=dbuser.admin)
     logger.info(f'New user "{dbuser.username}" added')
     return user
+
+
+@router.post("/users/bulk", response_model=List[UserResponse], responses={400: responses._400, 409: responses._409})
+def add_bulk_users(
+    bulk_user: BulkUserCreate,
+    bg: BackgroundTasks,
+    db: Session = Depends(get_db),
+    admin: Admin = Depends(Admin.get_current),
+):
+    """Add multiple users sequentially"""
+
+    created_users = []
+
+    for i in range(bulk_user.bulk_count):
+        username = f"{bulk_user.username}_{i + 1}"
+        new_user = bulk_user.model_copy()
+        new_user.username = username
+
+        for proxy_type in new_user.proxies:
+            if not xray.config.inbounds_by_protocol.get(proxy_type):
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Protocol {proxy_type} is disabled on your server",
+                )
+
+        try:
+            dbuser = crud.create_user(
+                db, new_user, admin=crud.get_admin(db, admin.username)
+            )
+        except IntegrityError:
+            db.rollback()
+            raise HTTPException(status_code=409, detail="User already exists")
+
+        bg.add_task(xray.operations.add_user, dbuser=dbuser)
+        user = UserResponse.model_validate(dbuser)
+        report.user_created(user=user, user_id=dbuser.id, by=admin, user_admin=dbuser.admin)
+        logger.info(f'New user "{dbuser.username}" added')
+        created_users.append(user)
+
+    return created_users
 
 
 @router.get("/user/{username}", response_model=UserResponse, responses={403: responses._403, 404: responses._404})


### PR DESCRIPTION
## Summary
- create `BulkUserCreate` model
- add `/users/bulk` API endpoint for sequential creation
- update dashboard types and context to use new endpoint
- modify user dialog to call bulk API when bulk count is more than 1

## Testing
- `python -m py_compile app/models/user.py app/routers/user.py`
- `node -v`

------
https://chatgpt.com/codex/tasks/task_b_684b6ae16308832dae06b9fa0fe71691