### PR TITLE
Implement bulk user creation

### DIFF
--- a/app/dashboard/src/components/UserDialog.tsx
+++ b/app/dashboard/src/components/UserDialog.tsx
@@ -225,6 +225,7 @@ export const UserDialog: FC<UserDialogProps> = () => {
     fetchUserUsage,
     onEditingUser,
     createUser,
+    createUsersBulk,
     onDeletingUser,
     inbounds,
   } = useDashboard();
@@ -340,13 +341,7 @@ export const UserDialog: FC<UserDialogProps> = () => {
     try {
       const count = values.bulk_count || 1;
       if (!isEditing && count > 1) {
-        for (let i = 0; i < count; i++) {
-          const username = `${values.username}_${i + 1}`;
-          // Ensure each user is created sequentially
-          await createUser({ ...body, username });
-          // Add a small delay between each creation
-          await new Promise((resolve) => setTimeout(resolve, 5));
-        }
+        await createUsersBulk({ ...body, bulk_count: count });
       } else {
         await create();
       }

--- a/app/dashboard/src/contexts/DashboardContext.tsx
+++ b/app/dashboard/src/contexts/DashboardContext.tsx
@@ -1,6 +1,6 @@
 import { StatisticsQueryKey } from "components/Statistics";
 import { fetch } from "service/http";
-import { User, UserCreate } from "types/User";
+import { User, UserCreate, BulkUserCreate } from "types/User";
 import { queryClient } from "utils/react-query";
 import { getUsersPerPageLimitSize } from "utils/userPreferenceStorage";
 import { create } from "zustand";
@@ -65,6 +65,7 @@ type DashboardStateType = {
   onFilterChange: (filters: Partial<FilterType>) => void;
   deleteUser: (user: User) => Promise<void>;
   createUser: (user: UserCreate) => Promise<void>;
+  createUsersBulk: (user: BulkUserCreate) => Promise<void>;
   editUser: (user: UserCreate) => Promise<void>;
   fetchUserUsage: (user: User, query: FilterUsageType) => Promise<void>;
   setQRCode: (links: string[] | null) => void;
@@ -187,6 +188,12 @@ export const useDashboard = create(
     },
     createUser: async (body: UserCreate) => {
       await fetch(`/user`, { method: "POST", body });
+      set({ editingUser: null });
+      get().refetchUsers();
+      queryClient.invalidateQueries(StatisticsQueryKey);
+    },
+    createUsersBulk: async (body: BulkUserCreate) => {
+      await fetch(`/users/bulk`, { method: "POST", body });
       set({ editingUser: null });
       get().refetchUsers();
       queryClient.invalidateQueries(StatisticsQueryKey);

--- a/app/dashboard/src/types/User.ts
+++ b/app/dashboard/src/types/User.ts
@@ -65,6 +65,8 @@ export type UserCreate = Pick<
   | "note"
 >;
 
+export type BulkUserCreate = UserCreate & { bulk_count: number };
+
 export type UserApi = {
   discord_webook: string;
   is_sudo: boolean;

--- a/app/db/crud.py
+++ b/app/db/crud.py
@@ -54,7 +54,8 @@ def add_default_host(db: Session, inbound: ProxyInbound):
         db (Session): Database session.
         inbound (ProxyInbound): Proxy inbound to add the default host to.
     """
-    host = ProxyHost(remark="🚀 Marz ({USERNAME}) [{PROTOCOL} - {TRANSPORT}]", address="{SERVER_IP}", inbound=inbound)
+    host = ProxyHost(
+        remark="🚀 Marz ({USERNAME}) [{PROTOCOL} - {TRANSPORT}]", address="{SERVER_IP}", inbound=inbound)
     db.add(host)
     db.commit()
 
@@ -70,7 +71,8 @@ def get_or_create_inbound(db: Session, inbound_tag: str) -> ProxyInbound:
     Returns:
         ProxyInbound: The retrieved or newly created proxy inbound.
     """
-    inbound = db.query(ProxyInbound).filter(ProxyInbound.tag == inbound_tag).first()
+    inbound = db.query(ProxyInbound).filter(
+        ProxyInbound.tag == inbound_tag).first()
     if not inbound:
         inbound = ProxyInbound(tag=inbound_tag)
         db.add(inbound)
@@ -254,7 +256,8 @@ def get_users(db: Session,
     query = get_user_queryset(db)
 
     if search:
-        query = query.filter(or_(User.username.ilike(f"%{search}%"), User.note.ilike(f"%{search}%")))
+        query = query.filter(or_(User.username.ilike(
+            f"%{search}%"), User.note.ilike(f"%{search}%")))
 
     if usernames:
         query = query.filter(User.username.in_(usernames))
@@ -267,9 +270,11 @@ def get_users(db: Session,
 
     if reset_strategy:
         if isinstance(reset_strategy, list):
-            query = query.filter(User.data_limit_reset_strategy.in_(reset_strategy))
+            query = query.filter(
+                User.data_limit_reset_strategy.in_(reset_strategy))
         else:
-            query = query.filter(User.data_limit_reset_strategy == reset_strategy)
+            query = query.filter(
+                User.data_limit_reset_strategy == reset_strategy)
 
     if admin:
         query = query.filter(User.admin == admin)
@@ -403,6 +408,16 @@ def create_user(db: Session, user: UserCreate, admin: Admin = None) -> User:
     return dbuser
 
 
+def create_users_bulk(db: Session, user: UserCreate, count: int, admin: Admin = None) -> List[User]:
+    users = []
+    for i in range(count):
+        new_user = user.model_copy()
+        new_user.username = f"{user.username}_{i + 1}" if count > 1 else user.username
+        db_user = create_user(db, new_user, admin)
+        users.append(db_user)
+    return users
+
+
 def remove_user(db: Session, dbuser: User) -> User:
     """
     Removes a user from the database.
@@ -454,7 +469,8 @@ def update_user(db: Session, dbuser: User, modify: UserModify) -> User:
             if dbproxy:
                 dbproxy.settings = settings.dict(no_obj=True)
             else:
-                new_proxy = Proxy(type=proxy_type, settings=settings.dict(no_obj=True))
+                new_proxy = Proxy(
+                    type=proxy_type, settings=settings.dict(no_obj=True))
                 dbuser.proxies.append(new_proxy)
                 added_proxies.update({proxy_type: new_proxy})
         for proxy in dbuser.proxies:
@@ -466,7 +482,8 @@ def update_user(db: Session, dbuser: User, modify: UserModify) -> User:
                 .where(Proxy.user == dbuser, Proxy.type == proxy_type) \
                 .first() or added_proxies.get(proxy_type)
             if dbproxy:
-                dbproxy.excluded_inbounds = [get_or_create_inbound(db, tag) for tag in tags]
+                dbproxy.excluded_inbounds = [
+                    get_or_create_inbound(db, tag) for tag in tags]
 
     if modify.status is not None:
         dbuser.status = modify.status
@@ -481,7 +498,8 @@ def update_user(db: Session, dbuser: User, modify: UserModify) -> User:
                 for percent in sorted(NOTIFY_REACHED_USAGE_PERCENT, reverse=True):
                     if not dbuser.data_limit or (calculate_usage_percent(
                             dbuser.used_traffic, dbuser.data_limit) < percent):
-                        reminder = get_notification_reminder(db, dbuser.id, ReminderType.data_usage, threshold=percent)
+                        reminder = get_notification_reminder(
+                            db, dbuser.id, ReminderType.data_usage, threshold=percent)
                         if reminder:
                             delete_notification_reminder(db, reminder)
 
@@ -589,7 +607,8 @@ def reset_user_by_next(db: Session, dbuser: User) -> User:
     dbuser.status = UserStatus.active.value
 
     dbuser.data_limit = dbuser.next_plan.data_limit + \
-        (0 if dbuser.next_plan.add_remaining_traffic else dbuser.data_limit - dbuser.used_traffic)
+        (0 if dbuser.next_plan.add_remaining_traffic else dbuser.data_limit -
+         dbuser.used_traffic)
     dbuser.expire = dbuser.next_plan.expire
 
     dbuser.used_traffic = 0
@@ -681,11 +700,13 @@ def disable_all_active_users(db: Session, admin: Optional[Admin] = None):
         db (Session): Database session.
         admin (Optional[Admin]): Admin to filter users by, if any.
     """
-    query = db.query(User).filter(User.status.in_((UserStatus.active, UserStatus.on_hold)))
+    query = db.query(User).filter(User.status.in_(
+        (UserStatus.active, UserStatus.on_hold)))
     if admin:
         query = query.filter(User.admin == admin)
 
-    query.update({User.status: UserStatus.disabled, User.last_status_change: datetime.utcnow()}, synchronize_session=False)
+    query.update({User.status: UserStatus.disabled,
+                 User.last_status_change: datetime.utcnow()}, synchronize_session=False)
 
     db.commit()
 
@@ -698,15 +719,18 @@ def activate_all_disabled_users(db: Session, admin: Optional[Admin] = None):
         db (Session): Database session.
         admin (Optional[Admin]): Admin to filter users by, if any.
     """
-    query_for_active_users = db.query(User).filter(User.status == UserStatus.disabled)
+    query_for_active_users = db.query(User).filter(
+        User.status == UserStatus.disabled)
     query_for_on_hold_users = db.query(User).filter(
         and_(
             User.status == UserStatus.disabled, User.expire.is_(
                 None), User.on_hold_expire_duration.isnot(None), User.online_at.is_(None)
         ))
     if admin:
-        query_for_active_users = query_for_active_users.filter(User.admin == admin)
-        query_for_on_hold_users = query_for_on_hold_users.filter(User.admin == admin)
+        query_for_active_users = query_for_active_users.filter(
+            User.admin == admin)
+        query_for_on_hold_users = query_for_on_hold_users.filter(
+            User.admin == admin)
 
     query_for_on_hold_users.update(
         {User.status: UserStatus.on_hold, User.last_status_change: datetime.utcnow()}, synchronize_session=False)
@@ -853,7 +877,8 @@ def start_user_expire(db: Session, dbuser: User) -> User:
     Returns:
         User: The updated user object.
     """
-    expire = int(datetime.utcnow().timestamp()) + dbuser.on_hold_expire_duration
+    expire = int(datetime.utcnow().timestamp()) + \
+        dbuser.on_hold_expire_duration
     dbuser.expire = expire
     dbuser.on_hold_expire_duration = None
     dbuser.on_hold_timeout = None
@@ -1107,7 +1132,8 @@ def create_user_template(db: Session, user_template: UserTemplateCreate) -> User
         expire_duration=user_template.expire_duration,
         username_prefix=user_template.username_prefix,
         username_suffix=user_template.username_suffix,
-        inbounds=db.query(ProxyInbound).filter(ProxyInbound.tag.in_(inbound_tags)).all()
+        inbounds=db.query(ProxyInbound).filter(
+            ProxyInbound.tag.in_(inbound_tags)).all()
     )
     db.add(dbuser_template)
     db.commit()
@@ -1143,7 +1169,8 @@ def update_user_template(
         inbound_tags: List[str] = []
         for _, i in modified_user_template.inbounds.items():
             inbound_tags.extend(i)
-        dbuser_template.inbounds = db.query(ProxyInbound).filter(ProxyInbound.tag.in_(inbound_tags)).all()
+        dbuser_template.inbounds = db.query(ProxyInbound).filter(
+            ProxyInbound.tag.in_(inbound_tags)).all()
 
     db.commit()
     db.refresh(dbuser_template)
@@ -1408,7 +1435,8 @@ def create_notification_reminder(
     Returns:
         NotificationReminder: The newly created NotificationReminder object.
     """
-    reminder = NotificationReminder(type=reminder_type, expires_at=expires_at, user_id=user_id)
+    reminder = NotificationReminder(
+        type=reminder_type, expires_at=expires_at, user_id=user_id)
     if threshold is not None:
         reminder.threshold = threshold
     db.add(reminder)

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -13,7 +13,8 @@ from app.subscription.share import generate_v2ray_links
 from app.utils.jwt import create_subscription_token
 from config import XRAY_SUBSCRIPTION_PATH, XRAY_SUBSCRIPTION_URL_PREFIX
 
-USERNAME_REGEXP = re.compile(r"^(?=\w{3,32}\b)[a-zA-Z0-9-_@.]+(?:_[a-zA-Z0-9-_@.]+)*$")
+USERNAME_REGEXP = re.compile(
+    r"^(?=\w{3,32}\b)[a-zA-Z0-9-_@.]+(?:_[a-zA-Z0-9-_@.]+)*$")
 
 
 class ReminderType(str, Enum):
@@ -71,7 +72,8 @@ class User(BaseModel):
     sub_last_user_agent: Optional[str] = Field(None, nullable=True)
     online_at: Optional[datetime] = Field(None, nullable=True)
     on_hold_expire_duration: Optional[int] = Field(None, nullable=True)
-    on_hold_timeout: Optional[Union[datetime, None]] = Field(None, nullable=True)
+    on_hold_timeout: Optional[Union[datetime, None]
+                              ] = Field(None, nullable=True)
 
     auto_delete_in_days: Optional[int] = Field(None, nullable=True)
 
@@ -85,7 +87,9 @@ class User(BaseModel):
             return int(v)
         if isinstance(v, int):  # Allow integers directly
             return v
-        raise ValueError("data_limit must be an integer or a float, not a string")  # Reject strings
+        # Reject strings
+        raise ValueError(
+            "data_limit must be an integer or a float, not a string")
 
     @field_validator("proxies", mode="before")
     def validate_proxies(cls, v, values, **kwargs):
@@ -197,10 +201,16 @@ class UserCreate(User):
         expire = values.data.get("expire")
         if status == UserStatusCreate.on_hold:
             if (on_hold_expire == 0 or on_hold_expire is None):
-                raise ValueError("User cannot be on hold without a valid on_hold_expire_duration.")
+                raise ValueError(
+                    "User cannot be on hold without a valid on_hold_expire_duration.")
             if expire:
-                raise ValueError("User cannot be on hold with specified expire.")
+                raise ValueError(
+                    "User cannot be on hold with specified expire.")
         return status
+
+
+class BulkUserCreate(UserCreate):
+    bulk_count: int = Field(1, ge=1)
 
 
 class UserModify(User):
@@ -273,9 +283,11 @@ class UserModify(User):
         expire = values.data.get("expire")
         if status == UserStatusCreate.on_hold:
             if (on_hold_expire == 0 or on_hold_expire is None):
-                raise ValueError("User cannot be on hold without a valid on_hold_expire_duration.")
+                raise ValueError(
+                    "User cannot be on hold without a valid on_hold_expire_duration.")
             if expire:
-                raise ValueError("User cannot be on hold with specified expire.")
+                raise ValueError(
+                    "User cannot be on hold with specified expire.")
         return status
 
 
@@ -324,12 +336,14 @@ class UserResponse(User):
             return int(v)
         if isinstance(v, int):  # Allow integers directly
             return v
-        raise ValueError("must be an integer or a float, not a string")  # Reject strings
+        # Reject strings
+        raise ValueError("must be an integer or a float, not a string")
 
 
 class SubscriptionUserResponse(UserResponse):
     admin: Admin | None = Field(default=None, exclude=True)
-    excluded_inbounds: Dict[ProxyTypes, List[str]] | None = Field(None, exclude=True)
+    excluded_inbounds: Dict[ProxyTypes, List[str]
+                            ] | None = Field(None, exclude=True)
     note: str | None = Field(None, exclude=True)
     inbounds: Dict[ProxyTypes, List[str]] | None = Field(None, exclude=True)
     auto_delete_in_days: int | None = Field(None, exclude=True)
@@ -354,7 +368,8 @@ class UserUsageResponse(BaseModel):
             return int(v)
         if isinstance(v, int):  # Allow integers directly
             return v
-        raise ValueError("must be an integer or a float, not a string")  # Reject strings
+        # Reject strings
+        raise ValueError("must be an integer or a float, not a string")
 
 
 class UserUsagesResponse(BaseModel):

--- a/app/routers/user.py
+++ b/app/routers/user.py
@@ -10,6 +10,7 @@ from app.dependencies import get_expired_users_list, get_validated_user, validat
 from app.models.admin import Admin
 from app.models.user import (
     UserCreate,
+    BulkUserCreate,
     UserModify,
     UserResponse,
     UsersResponse,
@@ -19,7 +20,8 @@ from app.models.user import (
 )
 from app.utils import report, responses
 
-router = APIRouter(tags=["User"], prefix="/api", responses={401: responses._401})
+router = APIRouter(tags=["User"], prefix="/api",
+                   responses={401: responses._401})
 
 
 @router.post("/user", response_model=UserResponse, responses={400: responses._400, 409: responses._409})
@@ -64,9 +66,45 @@ def add_user(
 
     bg.add_task(xray.operations.add_user, dbuser=dbuser)
     user = UserResponse.model_validate(dbuser)
-    report.user_created(user=user, user_id=dbuser.id, by=admin, user_admin=dbuser.admin)
+    report.user_created(user=user, user_id=dbuser.id,
+                        by=admin, user_admin=dbuser.admin)
     logger.info(f'New user "{dbuser.username}" added')
     return user
+
+
+@router.post("/users/bulk", response_model=List[UserResponse], responses={400: responses._400, 409: responses._409})
+def add_users_bulk(
+    bulk_user: BulkUserCreate,
+    bg: BackgroundTasks,
+    db: Session = Depends(get_db),
+    admin: Admin = Depends(Admin.get_current),
+):
+    for proxy_type in bulk_user.proxies:
+        if not xray.config.inbounds_by_protocol.get(proxy_type):
+            raise HTTPException(
+                status_code=400,
+                detail=f"Protocol {proxy_type} is disabled on your server",
+            )
+
+    users = []
+    template = bulk_user.model_dump(exclude={"bulk_count"})
+    for i in range(bulk_user.bulk_count):
+        data = {**template, "username": f"{bulk_user.username}_{i + 1}"}
+        try:
+            new_user = UserCreate.model_validate(data)
+            dbuser = crud.create_user(
+                db, new_user, admin=crud.get_admin(db, admin.username))
+        except IntegrityError:
+            db.rollback()
+            raise HTTPException(status_code=409, detail="User already exists")
+        bg.add_task(xray.operations.add_user, dbuser=dbuser)
+        user = UserResponse.model_validate(dbuser)
+        report.user_created(user=user, user_id=dbuser.id,
+                            by=admin, user_admin=dbuser.admin)
+        logger.info(f'New user "{dbuser.username}" added')
+        users.append(user)
+
+    return users
 
 
 @router.get("/user/{username}", response_model=UserResponse, responses={403: responses._403, 404: responses._404})
@@ -117,7 +155,8 @@ def modify_user(
     else:
         bg.add_task(xray.operations.remove_user, dbuser=dbuser)
 
-    bg.add_task(report.user_updated, user=user, user_admin=dbuser.admin, by=admin)
+    bg.add_task(report.user_updated, user=user,
+                user_admin=dbuser.admin, by=admin)
 
     logger.info(f'User "{user.username}" modified')
 
@@ -307,7 +346,8 @@ def get_users_usage(
     start, end = validate_dates(start, end)
 
     usages = crud.get_all_users_usages(
-        db=db, start=start, end=end, admin=owner if admin.is_sudo else [admin.username]
+        db=db, start=start, end=end, admin=owner if admin.is_sudo else [
+            admin.username]
     )
 
     return {"usages": usages}
@@ -335,8 +375,10 @@ def set_owner(
 
 @router.get("/users/expired", response_model=List[str])
 def get_expired_users(
-    expired_after: Optional[datetime] = Query(None, example="2024-01-01T00:00:00"),
-    expired_before: Optional[datetime] = Query(None, example="2024-01-31T23:59:59"),
+    expired_after: Optional[datetime] = Query(
+        None, example="2024-01-01T00:00:00"),
+    expired_before: Optional[datetime] = Query(
+        None, example="2024-01-31T23:59:59"),
     db: Session = Depends(get_db),
     admin: Admin = Depends(Admin.get_current),
 ):
@@ -349,17 +391,21 @@ def get_expired_users(
     - If both are omitted, returns all expired users
     """
 
-    expired_after, expired_before = validate_dates(expired_after, expired_before)
+    expired_after, expired_before = validate_dates(
+        expired_after, expired_before)
 
-    expired_users = get_expired_users_list(db, admin, expired_after, expired_before)
+    expired_users = get_expired_users_list(
+        db, admin, expired_after, expired_before)
     return [u.username for u in expired_users]
 
 
 @router.delete("/users/expired", response_model=List[str])
 def delete_expired_users(
     bg: BackgroundTasks,
-    expired_after: Optional[datetime] = Query(None, example="2024-01-01T00:00:00"),
-    expired_before: Optional[datetime] = Query(None, example="2024-01-31T23:59:59"),
+    expired_after: Optional[datetime] = Query(
+        None, example="2024-01-01T00:00:00"),
+    expired_before: Optional[datetime] = Query(
+        None, example="2024-01-31T23:59:59"),
     db: Session = Depends(get_db),
     admin: Admin = Depends(Admin.get_current),
 ):
@@ -370,9 +416,11 @@ def delete_expired_users(
     - **expired_before** UTC datetime (optional)
     - At least one of expired_after or expired_before must be provided
     """
-    expired_after, expired_before = validate_dates(expired_after, expired_before)
+    expired_after, expired_before = validate_dates(
+        expired_after, expired_before)
 
-    expired_users = get_expired_users_list(db, admin, expired_after, expired_before)
+    expired_users = get_expired_users_list(
+        db, admin, expired_after, expired_before)
     removed_users = [u.username for u in expired_users]
 
     if not removed_users:


### PR DESCRIPTION
## Summary
- extend user model with `BulkUserCreate`
- add `create_users_bulk` helper in CRUD
- expose `/users/bulk` API endpoint
- support bulk creation from dashboard context and dialog

## Testing
- `autopep8 -i app/models/user.py app/db/crud.py app/routers/user.py`

------
https://chatgpt.com/codex/tasks/task_b_684b6ac17f00832d9b760af5badb66a7