### PR TITLE
Improve node connection stability

### DIFF
--- a/app/xray/node.py
+++ b/app/xray/node.py
@@ -99,20 +99,27 @@ class ReSTXRayNode:
 
         return config
 
-    def make_request(self, path: str, timeout: int, **params):
-        try:
-            res = self.session.post(self._rest_api_url + path, timeout=timeout,
-                                    json={"session_id": self._session_id, **params})
-            data = res.json()
-        except Exception as e:
-            exc = NodeAPIError(0, str(e))
-            raise exc
+    def make_request(self, path: str, timeout: int, retries: int = 3, **params):
+        last_exc = None
+        for attempt in range(retries):
+            try:
+                res = self.session.post(
+                    self._rest_api_url + path,
+                    timeout=timeout,
+                    json={"session_id": self._session_id, **params},
+                )
+                data = res.json()
 
-        if res.status_code == 200:
-            return data
-        else:
-            exc = NodeAPIError(res.status_code, data['detail'])
-            raise exc
+                if res.status_code == 200:
+                    return data
+
+                last_exc = NodeAPIError(res.status_code, data.get("detail"))
+            except Exception as e:
+                last_exc = NodeAPIError(0, str(e))
+
+            time.sleep(1)
+
+        raise last_exc
 
     @property
     def connected(self):

--- a/app/xray/operations.py
+++ b/app/xray/operations.py
@@ -1,5 +1,6 @@
 from functools import lru_cache
 from typing import TYPE_CHECKING
+import time
 
 from sqlalchemy.exc import SQLAlchemyError
 
@@ -220,10 +221,22 @@ def connect_node(node_id, config=None):
         if config is None:
             config = xray.config.include_db_users()
 
-        node.start(config)
-        version = node.get_version()
-        _change_node_status(node_id, NodeStatus.connected, version=version)
-        logger.info(f"Connected to \"{dbnode.name}\" node, xray run on v{version}")
+        for attempt in range(3):
+            try:
+                node.start(config)
+                version = node.get_version()
+                _change_node_status(node_id, NodeStatus.connected, version=version)
+                logger.info(
+                    f"Connected to \"{dbnode.name}\" node, xray run on v{version}"
+                )
+                break
+            except Exception as e:
+                if attempt == 2:
+                    raise
+                logger.info(
+                    f"Connection attempt {attempt + 1} failed: {e}. Retrying..."
+                )
+                time.sleep(2)
 
     except Exception as e:
         _change_node_status(node_id, NodeStatus.error, message=str(e))


### PR DESCRIPTION
## Summary
- retry REST API requests when connecting to nodes
- retry node connection attempts in `connect_node`

## Testing
- `python -m py_compile app/xray/node.py app/xray/operations.py`

------
https://chatgpt.com/codex/tasks/task_b_6861e75765648321b2b22fb6faf8c226