### PR TITLE
Fix Node started state sync

### DIFF
--- a/app/xray/node.py
+++ b/app/xray/node.py
@@ -127,7 +127,8 @@ class ReSTXRayNode:
     @property
     def started(self):
         res = self.make_request("/", timeout=3)
-        return res.get('started', False)
+        self._started = res.get('started', False)
+        return self._started
 
     @property
     def api(self):


### PR DESCRIPTION
## Summary
- ensure `ReSTXRayNode.started` keeps `_started` in sync with remote node state

## Testing
- `python -m py_compile app/xray/node.py`


------
https://chatgpt.com/codex/tasks/task_b_6861e1ae2498832193210db2f1536213