### PR TITLE
Fix connection reset classification

### DIFF
--- a/xray_api/exceptions.py
+++ b/xray_api/exceptions.py
@@ -35,7 +35,7 @@ class TagNotFoundError(XrayError):
 
 
 class ConnectionError(XrayError):
-    REGEXP = re.compile(r"Failed to connect to remote host|Socket closed|Broken pipe")
+    REGEXP = re.compile(r"Failed to connect to remote host|Socket closed|Broken pipe|Connection reset by peer")
 
     def __init__(self, details):
         super().__init__(details)


### PR DESCRIPTION
## Summary
- handle gRPC "Connection reset by peer" as a connection error

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_686238bf02508321a9ddbaf32adfd2c3