### PR TITLE
Fix TimeoutError crash

### DIFF
--- a/app/xray/operations.py
+++ b/app/xray/operations.py
@@ -33,7 +33,7 @@ def get_tls():
 def _add_user_to_inbound(api: XRayAPI, inbound_tag: str, account: Account):
     try:
         api.add_inbound_user(tag=inbound_tag, user=account, timeout=30)
-    except (xray.exc.EmailExistsError, xray.exc.ConnectionError):
+    except (xray.exc.EmailExistsError, xray.exc.ConnectionError, xray.exc.TimeoutError):
         pass
 
 
@@ -41,7 +41,7 @@ def _add_user_to_inbound(api: XRayAPI, inbound_tag: str, account: Account):
 def _remove_user_from_inbound(api: XRayAPI, inbound_tag: str, email: str):
     try:
         api.remove_inbound_user(tag=inbound_tag, email=email, timeout=30)
-    except (xray.exc.EmailNotFoundError, xray.exc.ConnectionError):
+    except (xray.exc.EmailNotFoundError, xray.exc.ConnectionError, xray.exc.TimeoutError):
         pass
 
 
@@ -49,11 +49,11 @@ def _remove_user_from_inbound(api: XRayAPI, inbound_tag: str, email: str):
 def _alter_inbound_user(api: XRayAPI, inbound_tag: str, account: Account):
     try:
         api.remove_inbound_user(tag=inbound_tag, email=account.email, timeout=30)
-    except (xray.exc.EmailNotFoundError, xray.exc.ConnectionError):
+    except (xray.exc.EmailNotFoundError, xray.exc.ConnectionError, xray.exc.TimeoutError):
         pass
     try:
         api.add_inbound_user(tag=inbound_tag, user=account, timeout=30)
-    except (xray.exc.EmailExistsError, xray.exc.ConnectionError):
+    except (xray.exc.EmailExistsError, xray.exc.ConnectionError, xray.exc.TimeoutError):
         pass
 
 


### PR DESCRIPTION
## Summary
- handle gRPC timeouts when adding or removing inbound users

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_68623d95f99c832182697159a7046310