### PR TITLE
Handle DB lock timeouts with commit retry

### DIFF
--- a/app/db/crud.py
+++ b/app/db/crud.py
@@ -8,6 +8,8 @@ from typing import Dict, List, Optional, Tuple, Union
 
 from sqlalchemy import and_, delete, func, or_
 from sqlalchemy.orm import Query, Session, joinedload
+
+from app.db.utils import commit_with_retry
 from sqlalchemy.sql.functions import coalesce
 
 from app.db.models import (
@@ -398,7 +400,7 @@ def create_user(db: Session, user: UserCreate, admin: Admin = None) -> User:
         ) if user.next_plan else None
     )
     db.add(dbuser)
-    db.commit()
+    commit_with_retry(db)
     db.refresh(dbuser)
     return dbuser
 
@@ -527,7 +529,7 @@ def update_user(db: Session, dbuser: User, modify: UserModify) -> User:
 
     dbuser.edit_at = datetime.utcnow()
 
-    db.commit()
+    commit_with_retry(db)
     db.refresh(dbuser)
     return dbuser
 
@@ -559,7 +561,7 @@ def reset_user_data_usage(db: Session, dbuser: User) -> User:
         dbuser.next_plan = None
     db.add(dbuser)
 
-    db.commit()
+    commit_with_retry(db)
     db.refresh(dbuser)
     return dbuser
 
@@ -597,7 +599,7 @@ def reset_user_by_next(db: Session, dbuser: User) -> User:
     dbuser.next_plan = None
     db.add(dbuser)
 
-    db.commit()
+    commit_with_retry(db)
     db.refresh(dbuser)
     return dbuser
 
@@ -621,7 +623,7 @@ def revoke_user_sub(db: Session, dbuser: User) -> User:
         user.proxies[proxy_type] = settings
     dbuser = update_user(db, dbuser, user)
 
-    db.commit()
+    commit_with_retry(db)
     db.refresh(dbuser)
     return dbuser
 
@@ -641,7 +643,7 @@ def update_user_sub(db: Session, dbuser: User, user_agent: str) -> User:
     dbuser.sub_updated_at = datetime.utcnow()
     dbuser.sub_last_user_agent = user_agent
 
-    db.commit()
+    commit_with_retry(db)
     db.refresh(dbuser)
     return dbuser
 

--- a/app/db/utils.py
+++ b/app/db/utils.py
@@ -1,0 +1,24 @@
+import time
+from sqlalchemy.exc import OperationalError
+from sqlalchemy.orm import Session
+
+
+def commit_with_retry(db: Session, retries: int = 3, backoff: float = 0.5) -> None:
+    """Commit the session with retries on lock timeout errors.
+
+    Args:
+        db (Session): Database session.
+        retries (int): Number of retries before giving up.
+        backoff (float): Initial backoff time in seconds.
+    """
+    for attempt in range(retries):
+        try:
+            db.commit()
+            return
+        except OperationalError as exc:
+            if getattr(exc.orig, "args", [None])[0] == 1205:  # Lock wait timeout
+                db.rollback()
+                if attempt < retries - 1:
+                    time.sleep(backoff * (2 ** attempt))
+                    continue
+            raise


### PR DESCRIPTION
## Summary
- add `commit_with_retry` helper to retry DB transactions
- use the new helper when updating user subscription and other sensitive writes

## Testing
- `python -m compileall -q app/db/utils.py app/db/crud.py`
- `python -m compileall -q app/db`

------
https://chatgpt.com/codex/tasks/task_b_6864fa4515f08321852a2de1e11bbf79