### PR TITLE
Clamp timestamp when setting expiration

### DIFF
--- a/app/db/crud.py
+++ b/app/db/crud.py
@@ -42,7 +42,11 @@ from app.models.user import (
     UserUsageResponse,
 )
 from app.models.user_template import UserTemplateCreate, UserTemplateModify
-from app.utils.helpers import calculate_expiration_days, calculate_usage_percent
+from app.utils.helpers import (
+    calculate_expiration_days,
+    calculate_usage_percent,
+    clamp_timestamp,
+)
 from config import NOTIFY_DAYS_LEFT, NOTIFY_REACHED_USAGE_PERCENT, USERS_AUTODELETE_DAYS
 
 
@@ -383,7 +387,7 @@ def create_user(db: Session, user: UserCreate, admin: Admin = None) -> User:
         proxies=proxies,
         status=user.status,
         data_limit=(user.data_limit or None),
-        expire=(user.expire or None),
+        expire=clamp_timestamp(user.expire or None),
         admin=admin,
         data_limit_reset_strategy=user.data_limit_reset_strategy,
         note=user.note,
@@ -392,7 +396,7 @@ def create_user(db: Session, user: UserCreate, admin: Admin = None) -> User:
         auto_delete_in_days=user.auto_delete_in_days,
         next_plan=NextPlan(
             data_limit=user.next_plan.data_limit,
-            expire=user.next_plan.expire,
+            expire=clamp_timestamp(user.next_plan.expire),
             add_remaining_traffic=user.next_plan.add_remaining_traffic,
             fire_on_either=user.next_plan.fire_on_either,
         ) if user.next_plan else None
@@ -489,7 +493,7 @@ def update_user(db: Session, dbuser: User, modify: UserModify) -> User:
                 dbuser.status = UserStatus.limited
 
     if modify.expire is not None:
-        dbuser.expire = (modify.expire or None)
+        dbuser.expire = clamp_timestamp(modify.expire or None)
         if dbuser.status in (UserStatus.active, UserStatus.expired):
             if not dbuser.expire or dbuser.expire > datetime.utcnow().timestamp():
                 dbuser.status = UserStatus.active
@@ -518,7 +522,7 @@ def update_user(db: Session, dbuser: User, modify: UserModify) -> User:
     if modify.next_plan is not None:
         dbuser.next_plan = NextPlan(
             data_limit=modify.next_plan.data_limit,
-            expire=modify.next_plan.expire,
+            expire=clamp_timestamp(modify.next_plan.expire),
             add_remaining_traffic=modify.next_plan.add_remaining_traffic,
             fire_on_either=modify.next_plan.fire_on_either,
         )
@@ -590,7 +594,7 @@ def reset_user_by_next(db: Session, dbuser: User) -> User:
 
     dbuser.data_limit = dbuser.next_plan.data_limit + \
         (0 if dbuser.next_plan.add_remaining_traffic else dbuser.data_limit - dbuser.used_traffic)
-    dbuser.expire = dbuser.next_plan.expire
+    dbuser.expire = clamp_timestamp(dbuser.next_plan.expire)
 
     dbuser.used_traffic = 0
     db.delete(dbuser.next_plan)
@@ -854,7 +858,7 @@ def start_user_expire(db: Session, dbuser: User) -> User:
         User: The updated user object.
     """
     expire = int(datetime.utcnow().timestamp()) + dbuser.on_hold_expire_duration
-    dbuser.expire = expire
+    dbuser.expire = clamp_timestamp(expire)
     dbuser.on_hold_expire_duration = None
     dbuser.on_hold_timeout = None
     db.commit()

--- a/app/utils/helpers.py
+++ b/app/utils/helpers.py
@@ -1,6 +1,16 @@
 import json
 from datetime import datetime as dt
+from typing import Optional
 from uuid import UUID
+
+# Maximum UNIX timestamp that fits into a signed 32 bit integer
+MAX_UNIX_TIMESTAMP = 2 ** 31 - 1
+
+def clamp_timestamp(value: Optional[int]) -> Optional[int]:
+    """Clamp timestamp value to MAX_UNIX_TIMESTAMP."""
+    if value is None:
+        return None
+    return min(int(value), MAX_UNIX_TIMESTAMP)
 
 
 def calculate_usage_percent(used_traffic: int, data_limit: int) -> float:


### PR DESCRIPTION
## Summary
- avoid overflow for `expire` column
- enforce 32-bit max timestamp in user creation, update, next plan and start expire
- provide utility `clamp_timestamp`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6865c232c3b48321b9387ecd4c545bd4