### PR TITLE
Set xtls-rprx-vision as default user flow

### DIFF
--- a/app/dashboard/src/components/UserDialog.tsx
+++ b/app/dashboard/src/components/UserDialog.tsx
@@ -120,7 +120,7 @@ const getDefaultValues = (): FormType => {
     bulk_count: 1,
     inbounds,
     proxies: {
-      vless: { id: "", flow: "" },
+      vless: { id: "", flow: "xtls-rprx-vision" },
       vmess: { id: "" },
       trojan: { password: "" },
       shadowsocks: { password: "", method: "chacha20-ietf-poly1305" },

--- a/app/models/proxy.py
+++ b/app/models/proxy.py
@@ -73,7 +73,7 @@ class VMessSettings(ProxySettings):
 
 class VLESSSettings(ProxySettings):
     id: UUID = Field(default_factory=uuid4)
-    flow: XTLSFlows = XTLSFlows.NONE
+    flow: XTLSFlows = XTLSFlows.VISION
 
     def revoke(self):
         self.id = uuid4()
@@ -81,7 +81,7 @@ class VLESSSettings(ProxySettings):
 
 class TrojanSettings(ProxySettings):
     password: str = Field(default_factory=random_password)
-    flow: XTLSFlows = XTLSFlows.NONE
+    flow: XTLSFlows = XTLSFlows.VISION
 
     def revoke(self):
         self.password = random_password()


### PR DESCRIPTION
## Summary
- set xtls-rprx-vision as the default XTLS flow for VLESS and Trojan accounts
- update new user dialog to prefill the vision flow

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_686707d1036c83219f7a3b6f279c4c12