### PR TITLE
feat(frontend): show admin usage in statistics

### DIFF
--- a/app/dashboard/public/statics/locales/en.json
+++ b/app/dashboard/public/statics/locales/en.json
@@ -17,6 +17,7 @@
   "core.title": "Core Settings",
   "createNewUser": "Create new user",
   "createUser": "Create User",
+  "adminUsage": "your usage",
   "dataUsage": "data usage",
   "dateFormat": "MMMM d, yyy",
   "delete": "Delete",

--- a/app/dashboard/public/statics/locales/en.json
+++ b/app/dashboard/public/statics/locales/en.json
@@ -17,7 +17,7 @@
   "core.title": "Core Settings",
   "createNewUser": "Create new user",
   "createUser": "Create User",
-  "adminUsage": "users usage",
+  "UsersUsage": "Users Usage",
   "dataUsage": "data usage",
   "dateFormat": "MMMM d, yyy",
   "delete": "Delete",

--- a/app/dashboard/public/statics/locales/en.json
+++ b/app/dashboard/public/statics/locales/en.json
@@ -17,7 +17,7 @@
   "core.title": "Core Settings",
   "createNewUser": "Create new user",
   "createUser": "Create User",
-  "adminUsage": "your usage",
+  "adminUsage": "users usage",
   "dataUsage": "data usage",
   "dateFormat": "MMMM d, yyy",
   "delete": "Delete",

--- a/app/dashboard/public/statics/locales/fa.json
+++ b/app/dashboard/public/statics/locales/fa.json
@@ -17,7 +17,7 @@
   "core.title": "تنظیمات هسته",
   "createNewUser": "ساخت کاربر",
   "createUser": "افزودن کاربر",
-  "adminUsage": "مصرف کاربران",
+  "UsersUsage": "مصرف کاربران",
   "dataUsage": "مصرف داده",
   "dateFormat": "MM/dd/yyyy",
   "dateInfo.day": " روز",

--- a/app/dashboard/public/statics/locales/fa.json
+++ b/app/dashboard/public/statics/locales/fa.json
@@ -17,7 +17,7 @@
   "core.title": "تنظیمات هسته",
   "createNewUser": "ساخت کاربر",
   "createUser": "افزودن کاربر",
-  "adminUsage": "مصرف شما",
+  "adminUsage": "مصرف کاربران",
   "dataUsage": "مصرف داده",
   "dateFormat": "MM/dd/yyyy",
   "dateInfo.day": " روز",

--- a/app/dashboard/public/statics/locales/fa.json
+++ b/app/dashboard/public/statics/locales/fa.json
@@ -17,6 +17,7 @@
   "core.title": "تنظیمات هسته",
   "createNewUser": "ساخت کاربر",
   "createUser": "افزودن کاربر",
+  "adminUsage": "مصرف شما",
   "dataUsage": "مصرف داده",
   "dateFormat": "MM/dd/yyyy",
   "dateInfo.day": " روز",

--- a/app/dashboard/public/statics/locales/ru.json
+++ b/app/dashboard/public/statics/locales/ru.json
@@ -17,6 +17,7 @@
   "core.title": "Основные настройки",
   "createNewUser": "Создать нового пользователя",
   "createUser": "Создать",
+  "adminUsage": "Ваше использование",
   "dataUsage": "Трафик",
   "dateFormat": "MMMM d, yyy",
   "delete": "Удалить",

--- a/app/dashboard/public/statics/locales/ru.json
+++ b/app/dashboard/public/statics/locales/ru.json
@@ -17,7 +17,7 @@
   "core.title": "Основные настройки",
   "createNewUser": "Создать нового пользователя",
   "createUser": "Создать",
-  "adminUsage": "Ваше использование",
+  "UsersUsage": "Ваше использование",
   "dataUsage": "Трафик",
   "dateFormat": "MMMM d, yyy",
   "delete": "Удалить",

--- a/app/dashboard/public/statics/locales/zh.json
+++ b/app/dashboard/public/statics/locales/zh.json
@@ -17,7 +17,7 @@
   "core.title": "核心设置",
   "createNewUser": "创建新用户",
   "createUser": "创建用户",
-  "adminUsage": "您的用量",
+  "UsersUsage": "您的用量",
   "dataUsage": "总流量",
   "dateFormat": "MM/dd/yyyy",
   "delete": "删除",

--- a/app/dashboard/public/statics/locales/zh.json
+++ b/app/dashboard/public/statics/locales/zh.json
@@ -17,6 +17,7 @@
   "core.title": "核心设置",
   "createNewUser": "创建新用户",
   "createUser": "创建用户",
+  "adminUsage": "您的用量",
   "dataUsage": "总流量",
   "dateFormat": "MM/dd/yyyy",
   "delete": "删除",

--- a/app/dashboard/src/components/Statistics.tsx
+++ b/app/dashboard/src/components/Statistics.tsx
@@ -162,7 +162,7 @@ export const Statistics: FC<BoxProps> = (props) => {
         icon={<TotalUsersIcon />}
       />
       <StatisticCard
-        title={t("adminUsage")}
+        title={t("UsersUsage")}
         content={formatBytes(userData.users_usage ?? 0)}
         icon={<NetworkIcon />}
       />

--- a/app/dashboard/src/components/Statistics.tsx
+++ b/app/dashboard/src/components/Statistics.tsx
@@ -5,6 +5,7 @@ import {
   UsersIcon,
 } from "@heroicons/react/24/outline";
 import { useDashboard } from "contexts/DashboardContext";
+import useGetUser from "hooks/useGetUser";
 import { FC, PropsWithChildren, ReactElement, ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import { useQuery } from "react-query";
@@ -119,6 +120,7 @@ const StatisticCard: FC<PropsWithChildren<StatisticCardProps>> = ({
 export const StatisticsQueryKey = "statistics-query-key";
 export const Statistics: FC<BoxProps> = (props) => {
   const { version } = useDashboard();
+  const { userData } = useGetUser();
   const { data: systemData } = useQuery({
     queryKey: StatisticsQueryKey,
     queryFn: () => fetch("/system"),
@@ -160,13 +162,8 @@ export const Statistics: FC<BoxProps> = (props) => {
         icon={<TotalUsersIcon />}
       />
       <StatisticCard
-        title={t("dataUsage")}
-        content={
-          systemData &&
-          formatBytes(
-            systemData.incoming_bandwidth + systemData.outgoing_bandwidth
-          )
-        }
+        title={t("adminUsage")}
+        content={formatBytes(userData.users_usage ?? 0)}
         icon={<NetworkIcon />}
       />
       <StatisticCard

--- a/app/dashboard/src/components/Statistics.tsx
+++ b/app/dashboard/src/components/Statistics.tsx
@@ -124,7 +124,7 @@ export const Statistics: FC<BoxProps> = (props) => {
   const { data: systemData } = useQuery({
     queryKey: StatisticsQueryKey,
     queryFn: () => fetch("/system"),
-    refetchInterval: 60_000,
+    refetchInterval: 600_000,
     onSuccess: ({ version: currentVersion }) => {
       if (version !== currentVersion)
         useDashboard.setState({ version: currentVersion });

--- a/app/dashboard/src/components/Statistics.tsx
+++ b/app/dashboard/src/components/Statistics.tsx
@@ -124,7 +124,7 @@ export const Statistics: FC<BoxProps> = (props) => {
   const { data: systemData } = useQuery({
     queryKey: StatisticsQueryKey,
     queryFn: () => fetch("/system"),
-    refetchInterval: 5000,
+    refetchInterval: 60_000,
     onSuccess: ({ version: currentVersion }) => {
       if (version !== currentVersion)
         useDashboard.setState({ version: currentVersion });

--- a/app/dashboard/src/hooks/useGetUser.tsx
+++ b/app/dashboard/src/hooks/useGetUser.tsx
@@ -16,7 +16,8 @@ const useGetUser = (): UseGetUserReturn => {
         discord_webook: "",
         is_sudo: false,
         telegram_id: "",
-        username: ""
+        username: "",
+        users_usage: 0
       }
     
     return {

--- a/app/dashboard/src/types/User.ts
+++ b/app/dashboard/src/types/User.ts
@@ -70,6 +70,7 @@ export type UserApi = {
   is_sudo: boolean;
   telegram_id: number | string;
   username: string;
+  users_usage?: number | null;
 }
 
 export type UseGetUserReturn = {


### PR DESCRIPTION
## Summary
- display the logged-in admin's usage in the dashboard statistics instead of overall data usage
- expose the users_usage field through the admin hook and add locale strings for the new label

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d0727510508326a69cc2c33a430963