### PR TITLE
Increase node operation timeouts

### DIFF
--- a/app/jobs/0_xray_core.py
+++ b/app/jobs/0_xray_core.py
@@ -22,7 +22,7 @@ def core_health_check():
         if node.connected:
             try:
                 assert node.started
-                node.api.get_sys_stats(timeout=2)
+                node.api.get_sys_stats(timeout=40)
             except (ConnectionError, xray_exc.XrayError, AssertionError):
                 if not config:
                     config = xray.config.include_db_users()

--- a/app/jobs/record_usages.py
+++ b/app/jobs/record_usages.py
@@ -110,7 +110,7 @@ def record_node_stats(params: dict, node_id: Union[int, None]):
 def get_users_stats(api: XRayAPI):
     try:
         params = defaultdict(int)
-        for stat in filter(attrgetter('value'), api.get_users_stats(reset=True, timeout=30)):
+        for stat in filter(attrgetter('value'), api.get_users_stats(reset=True, timeout=600)):
             params[stat.name.split('.', 1)[0]] += stat.value
         params = list({"uid": uid, "value": value} for uid, value in params.items())
         return params
@@ -121,7 +121,7 @@ def get_users_stats(api: XRayAPI):
 def get_outbounds_stats(api: XRayAPI):
     try:
         params = [{"up": stat.value, "down": 0} if stat.link == "uplink" else {"up": 0, "down": stat.value}
-                  for stat in filter(attrgetter('value'), api.get_outbounds_stats(reset=True, timeout=10))]
+                  for stat in filter(attrgetter('value'), api.get_outbounds_stats(reset=True, timeout=200))]
         return params
     except xray_exc.XrayError:
         return []

--- a/app/routers/node.py
+++ b/app/routers/node.py
@@ -128,7 +128,7 @@ async def node_logs(node_id: int, websocket: WebSocket, db: Session = Depends(ge
 
             if not logs:
                 try:
-                    await asyncio.wait_for(websocket.receive(), timeout=0.2)
+                    await asyncio.wait_for(websocket.receive(), timeout=4)
                     continue
                 except asyncio.TimeoutError:
                     continue

--- a/app/xray/node.py
+++ b/app/xray/node.py
@@ -119,14 +119,14 @@ class ReSTXRayNode:
         if not self._session_id:
             return False
         try:
-            self.make_request("/ping", timeout=3)
+            self.make_request("/ping", timeout=60)
             return True
         except NodeAPIError:
             return False
 
     @property
     def started(self):
-        res = self.make_request("/", timeout=3)
+        res = self.make_request("/", timeout=60)
         return res.get('started', False)
 
     @property
@@ -152,15 +152,15 @@ class ReSTXRayNode:
         self._node_certfile = string_to_temp_file(self._node_cert)
         self.session.verify = self._node_certfile.name
 
-        res = self.make_request("/connect", timeout=3)
+        res = self.make_request("/connect", timeout=60)
         self._session_id = res['session_id']
 
     def disconnect(self):
-        self.make_request("/disconnect", timeout=3)
+        self.make_request("/disconnect", timeout=60)
         self._session_id = None
 
     def get_version(self):
-        res = self.make_request("/", timeout=3)
+        res = self.make_request("/", timeout=60)
         return res.get('core_version')
 
     def start(self, config: XRayConfig):
@@ -171,7 +171,7 @@ class ReSTXRayNode:
         json_config = config.to_json()
 
         try:
-            res = self.make_request("/start", timeout=10, config=json_config)
+            res = self.make_request("/start", timeout=200, config=json_config)
         except NodeAPIError as exc:
             if exc.detail == 'Xray is started already':
                 return self.restart(config)
@@ -188,7 +188,7 @@ class ReSTXRayNode:
         )
 
         try:
-            grpc.channel_ready_future(self._api._channel).result(timeout=5)
+            grpc.channel_ready_future(self._api._channel).result(timeout=100)
         except grpc.FutureTimeoutError:
             raise ConnectionError('Failed to connect to node\'s API')
 
@@ -198,7 +198,7 @@ class ReSTXRayNode:
         if not self.connected:
             self.connect()
 
-        self.make_request('/stop', timeout=5)
+        self.make_request('/stop', timeout=100)
         self._api = None
         self._started = False
 
@@ -209,7 +209,7 @@ class ReSTXRayNode:
         config = self._prepare_config(config)
         json_config = config.to_json()
 
-        res = self.make_request("/restart", timeout=10, config=json_config)
+        res = self.make_request("/restart", timeout=200, config=json_config)
 
         self._started = True
 
@@ -221,7 +221,7 @@ class ReSTXRayNode:
         )
 
         try:
-            grpc.channel_ready_future(self._api._channel).result(timeout=5)
+            grpc.channel_ready_future(self._api._channel).result(timeout=100)
         except grpc.FutureTimeoutError:
             raise ConnectionError('Failed to connect to node\'s API')
 
@@ -232,7 +232,7 @@ class ReSTXRayNode:
             try:
                 websocket_url = f"{self._logs_ws_url}?session_id={self._session_id}&interval=0.7"
                 self._ssl_context.load_verify_locations(self.session.verify)
-                ws = create_connection(websocket_url, sslopt={"context": self._ssl_context}, timeout=2)
+                ws = create_connection(websocket_url, sslopt={"context": self._ssl_context}, timeout=40)
                 while self._logs_queues:
                     try:
                         logs = ws.recv()
@@ -417,11 +417,11 @@ class RPyCXRayNode:
             ssl_target_name="Gozargah"
         )
         try:
-            grpc.channel_ready_future(self._api._channel).result(timeout=5)
+            grpc.channel_ready_future(self._api._channel).result(timeout=100)
         except grpc.FutureTimeoutError:
 
             start_time = time.time()
-            end_time = start_time + 3  # check logs for 3 seconds
+            end_time = start_time + 60  # check logs for 60 seconds
             last_log = ''
             with self.get_logs() as logs:
                 while time.time() < end_time:
@@ -505,7 +505,7 @@ class XRayNode:
         # trying to detect what's the server of node
         try:
             s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            s.settimeout(1)
+            s.settimeout(20)
             s.connect((address, port))
             s.send(b'HEAD / HTTP/1.0\r\n\r\n')
             s.recv(1024)

--- a/app/xray/operations.py
+++ b/app/xray/operations.py
@@ -31,7 +31,7 @@ def get_tls():
 @threaded_function
 def _add_user_to_inbound(api: XRayAPI, inbound_tag: str, account: Account):
     try:
-        api.add_inbound_user(tag=inbound_tag, user=account, timeout=30)
+        api.add_inbound_user(tag=inbound_tag, user=account, timeout=600)
     except (xray.exc.EmailExistsError, xray.exc.ConnectionError):
         pass
 
@@ -39,7 +39,7 @@ def _add_user_to_inbound(api: XRayAPI, inbound_tag: str, account: Account):
 @threaded_function
 def _remove_user_from_inbound(api: XRayAPI, inbound_tag: str, email: str):
     try:
-        api.remove_inbound_user(tag=inbound_tag, email=email, timeout=30)
+        api.remove_inbound_user(tag=inbound_tag, email=email, timeout=600)
     except (xray.exc.EmailNotFoundError, xray.exc.ConnectionError):
         pass
 
@@ -47,11 +47,11 @@ def _remove_user_from_inbound(api: XRayAPI, inbound_tag: str, email: str):
 @threaded_function
 def _alter_inbound_user(api: XRayAPI, inbound_tag: str, account: Account):
     try:
-        api.remove_inbound_user(tag=inbound_tag, email=account.email, timeout=30)
+        api.remove_inbound_user(tag=inbound_tag, email=account.email, timeout=600)
     except (xray.exc.EmailNotFoundError, xray.exc.ConnectionError):
         pass
     try:
-        api.add_inbound_user(tag=inbound_tag, user=account, timeout=30)
+        api.add_inbound_user(tag=inbound_tag, user=account, timeout=600)
     except (xray.exc.EmailExistsError, xray.exc.ConnectionError):
         pass
 


### PR DESCRIPTION
## Summary
- increase Xray node REST and gRPC connection timeouts by 20x to make node startup and control calls more resilient
- scale node user synchronization helpers to use the longer timeouts when modifying inbound users
- extend node health checks, usage polling, and websocket log waits to align with the new timeout policy

## Testing
- python -m compileall app/xray app/jobs app/routers

------
https://chatgpt.com/codex/tasks/task_b_68d0944440b083268a0289dcb6c55207