### PR TITLE
Remove donation links from dashboard

### DIFF
--- a/app/dashboard/public/statics/locales/en.json
+++ b/app/dashboard/public/statics/locales/en.json
@@ -30,7 +30,6 @@
   "disabled": "disabled",
   "expired": "Expired {{time}} ago",
   "expires": "Expires in {{time}}",
-  "header.donation": "Donation",
   "header.hostSettings": "Host Settings",
   "header.logout": "Log out",
   "header.nodeSettings": "Node Settings",

--- a/app/dashboard/public/statics/locales/fa.json
+++ b/app/dashboard/public/statics/locales/fa.json
@@ -35,7 +35,6 @@
   "disabled": "غیر فعال",
   "expired": "{{time}} پیش به پایان رسیده",
   "expires": "پایان در {{time}}",
-  "header.donation": "کمک مالی",
   "header.hostSettings": "تنظیمات هاست",
   "header.logout": "خروج",
   "header.nodeSettings": "تنظیمات گره‌ها",

--- a/app/dashboard/public/statics/locales/ru.json
+++ b/app/dashboard/public/statics/locales/ru.json
@@ -30,7 +30,6 @@
   "disabled": "disabled",
   "expired": "Истекло {{time}} назад",
   "expires": "Истекает через {{time}}",
-  "header.donation": "Пожертвование",
   "header.hostSettings": "Настройки хоста",
   "header.logout": "Выйти",
   "header.nodeSettings": "Настройки узлов",

--- a/app/dashboard/public/statics/locales/zh.json
+++ b/app/dashboard/public/statics/locales/zh.json
@@ -30,7 +30,6 @@
   "disabled": "禁用",
   "expired": "{{time}}失效",
   "expires": "{{time}}有效",
-  "header.donation": "捐赠",
   "header.hostSettings": "设置",
   "header.logout": "退出",
   "header.nodeSettings": "节点设置",

--- a/app/dashboard/src/components/Header.tsx
+++ b/app/dashboard/src/components/Header.tsx
@@ -15,18 +15,15 @@ import {
   Bars3Icon,
   ChartPieIcon,
   Cog6ToothIcon,
-  CurrencyDollarIcon,
   DocumentMinusIcon,
   LinkIcon,
   MoonIcon,
   SquaresPlusIcon,
   SunIcon,
 } from "@heroicons/react/24/outline";
-import { DONATION_URL, REPO_URL } from "constants/Project";
+import { REPO_URL } from "constants/Project";
 import { useDashboard } from "contexts/DashboardContext";
-import differenceInDays from "date-fns/differenceInDays";
-import isValid from "date-fns/isValid";
-import { FC, ReactNode, useState } from "react";
+import { FC, ReactNode } from "react";
 import GitHubButton from "react-github-btn";
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
@@ -49,37 +46,10 @@ const LightIcon = chakra(SunIcon, iconProps);
 const CoreSettingsIcon = chakra(Cog6ToothIcon, iconProps);
 const SettingsIcon = chakra(Bars3Icon, iconProps);
 const LogoutIcon = chakra(ArrowLeftOnRectangleIcon, iconProps);
-const DonationIcon = chakra(CurrencyDollarIcon, iconProps);
 const HostsIcon = chakra(LinkIcon, iconProps);
 const NodesIcon = chakra(SquaresPlusIcon, iconProps);
 const NodesUsageIcon = chakra(ChartPieIcon, iconProps);
 const ResetUsageIcon = chakra(DocumentMinusIcon, iconProps);
-const NotificationCircle = chakra(Box, {
-  baseStyle: {
-    bg: "yellow.500",
-    w: "2",
-    h: "2",
-    rounded: "full",
-    position: "absolute",
-  },
-});
-
-const NOTIFICATION_KEY = "marzban-menu-notification";
-
-export const shouldShowDonation = (): boolean => {
-  const date = localStorage.getItem(NOTIFICATION_KEY);
-  if (!date) return true;
-  try {
-    if (date && isValid(parseInt(date))) {
-      if (differenceInDays(new Date(), new Date(parseInt(date))) >= 7)
-        return true;
-      return false;
-    }
-    return true;
-  } catch (err) {
-    return true;
-  }
-};
 
 export const Header: FC<HeaderProps> = ({ actions }) => {
   const { userData, getUserIsSuccess, getUserIsPending } = useGetUser();
@@ -99,15 +69,7 @@ export const Header: FC<HeaderProps> = ({ actions }) => {
   } = useDashboard();
   const { t } = useTranslation();
   const { colorMode, toggleColorMode } = useColorMode();
-  const [showDonationNotif, setShowDonationNotif] = useState(
-    shouldShowDonation()
-  );
   const gBtnColor = colorMode === "dark" ? "dark_dimmed" : colorMode;
-
-  const handleOnClose = () => {
-    localStorage.setItem(NOTIFICATION_KEY, new Date().getTime().toString());
-    setShowDonationNotif(false);
-  };
 
   return (
     <HStack
@@ -123,9 +85,6 @@ export const Header: FC<HeaderProps> = ({ actions }) => {
       <Text as="h1" fontWeight="semibold" fontSize="2xl">
         {t("users")}
       </Text>
-      {showDonationNotif && (
-        <NotificationCircle top="0" right="0" zIndex={9999} />
-      )}
       <Box overflow="auto" css={{ direction: "rtl" }}>
         <HStack alignItems="center">
           <Menu>
@@ -177,20 +136,6 @@ export const Header: FC<HeaderProps> = ({ actions }) => {
                   </MenuItem>
                 </>
               )}
-              <Link to={DONATION_URL} target="_blank">
-                <MenuItem
-                  maxW="170px"
-                  fontSize="sm"
-                  icon={<DonationIcon />}
-                  position="relative"
-                  onClick={handleOnClose}
-                >
-                  {t("header.donation")}{" "}
-                  {showDonationNotif && (
-                    <NotificationCircle top="3" right="2" />
-                  )}
-                </MenuItem>
-              </Link>
               <Link to="/login">
                 <MenuItem maxW="170px" fontSize="sm" icon={<LogoutIcon />}>
                   {t("header.logout")}

--- a/app/dashboard/src/constants/Project.ts
+++ b/app/dashboard/src/constants/Project.ts
@@ -1,3 +1,2 @@
 export const REPO_URL = "https://github.com/Gozargah/Marzban";
 export const ORGANIZATION_URL = "https://github.com/Gozargah";
-export const DONATION_URL = "https://github.com/Gozargah/Marzban#donation";


### PR DESCRIPTION
## Summary
- remove the donation menu item and notification logic from the dashboard header
- drop the unused donation URL constant
- clean up locale files by deleting the donation translation key

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d09927e180832690bfd6ec31dd2b83