### PR TITLE
feat: show admin users data usage on dashboard

### DIFF
--- a/app/dashboard/public/statics/locales/en.json
+++ b/app/dashboard/public/statics/locales/en.json
@@ -181,6 +181,7 @@
   "userDialog.weeks": "Weeks",
   "username": "Username",
   "users": "Users",
+  "usersUsage": "users usage",
   "usersTable.copied": "Copied",
   "usersTable.copyConfigs": "Copy Configs",
   "usersTable.copyLink": "Copy Subscription Link",

--- a/app/dashboard/public/statics/locales/fa.json
+++ b/app/dashboard/public/statics/locales/fa.json
@@ -60,7 +60,6 @@
   "hostsDialog.noise.info": "packet,delay (e.g. rand:10-20,100-200)",
   "hostsDialog.noise.info.attention": "توجه: در حال حاضر، این ویژگی فقط در streisand >= 1.6.32 و v2rayNG >= 1.8.39 (پیکربندی سفارشی) پشتیبانی می شود",
   "hostsDialog.noise.info.examples": "نمونه ها:",
-
   "hostsDialog.host": "هاست درخواست",
   "hostsDialog.host.info": "به‌طور پیش‌فرض، اگر هاست درخواستی در پیکربندی *** تنظیم شده باشد، این هاست استفاده می‌شود. اما می‌توانید یک هاست درخواستی متفاوت در اینجا قرار دهید.",
   "hostsDialog.host.multiHost": "برای تنظیم چند آدرس، با <badge>,</badge> از هم جدا کنید. هر دفعه آدرسی به صورت تصادفی قرار داده می‌شود.",
@@ -187,6 +186,7 @@
   "userDialog.weeks": "هفته‌ها",
   "username": "نام کاربری",
   "users": "کاربران",
+  "usersUsage": "مصرف کاربران",
   "usersTable.copied": "کپی شد",
   "usersTable.copyConfigs": "تنظیمات کپی",
   "usersTable.copyLink": "کپی لینک اشتراک",

--- a/app/dashboard/public/statics/locales/ru.json
+++ b/app/dashboard/public/statics/locales/ru.json
@@ -181,6 +181,7 @@
   "userDialog.weeks": "Недели",
   "username": "Имя пользователя",
   "users": "Пользователи",
+  "usersUsage": "Использование пользователей",
   "usersTable.copied": "Скопировано",
   "usersTable.copyConfigs": "Скопировать конфигурации",
   "usersTable.copyLink": "Скопировать ссылку на подписку",

--- a/app/dashboard/public/statics/locales/zh.json
+++ b/app/dashboard/public/statics/locales/zh.json
@@ -181,6 +181,7 @@
   "userDialog.weeks": "周",
   "username": "用户名",
   "users": "用户",
+  "usersUsage": "用户使用量",
   "usersTable.copied": "已复制",
   "usersTable.copyConfigs": "复制配置",
   "usersTable.copyLink": "复制订阅链接",

--- a/app/dashboard/src/components/Statistics.tsx
+++ b/app/dashboard/src/components/Statistics.tsx
@@ -160,11 +160,11 @@ export const Statistics: FC<BoxProps> = (props) => {
         icon={<TotalUsersIcon />}
       />
       <StatisticCard
-        title={t("dataUsage")}
+        title={t("usersUsage")}
         content={
           systemData &&
           formatBytes(
-            systemData.incoming_bandwidth + systemData.outgoing_bandwidth
+            systemData.total_user_traffic
           )
         }
         icon={<NetworkIcon />}

--- a/app/models/system.py
+++ b/app/models/system.py
@@ -18,3 +18,4 @@ class SystemStats(BaseModel):
     outgoing_bandwidth: int
     incoming_bandwidth_speed: int
     outgoing_bandwidth_speed: int
+    total_user_traffic: int

--- a/app/routers/system.py
+++ b/app/routers/system.py
@@ -60,6 +60,7 @@ def get_system_stats(
         outgoing_bandwidth=system.downlink,
         incoming_bandwidth_speed=realtime_bandwidth_stats.incoming_bytes,
         outgoing_bandwidth_speed=realtime_bandwidth_stats.outgoing_bytes,
+        total_user_traffic=dbadmin.users_usage if dbadmin and dbadmin.users_usage else 0,
     )
 
 

--- a/app/utils/system.py
+++ b/app/utils/system.py
@@ -71,7 +71,7 @@ rt_bw = RealtimeBandwidth(
 
 
 # sample time is 2 seconds, values lower than this may not produce good results
-@scheduler.scheduled_job("interval", seconds=2, coalesce=True, max_instances=1)
+@scheduler.scheduled_job("interval", seconds=20, coalesce=True, max_instances=1)
 def record_realtime_bandwidth() -> None:
     global rt_bw
     last_perf_counter = rt_bw.last_perf_counter


### PR DESCRIPTION
Replaced system data usage with logged-in admin's users usage in dashboard statistics. Updated realtime bandwidth job interval to 20s. Added localization for Users Usage.