### PR TITLE
Optimize review_users job to query only users needing review

### DIFF
--- a/app/db/__init__.py
+++ b/app/db/__init__.py
@@ -28,7 +28,7 @@ from .crud import (create_admin, create_notification_reminder,  # noqa
                    get_admins, get_jwt_secret_key, get_notification_reminder,
                    get_or_create_inbound, get_system_usage,
                    get_tls_certificate, get_user, get_user_by_id, get_users,
-                   get_users_count, remove_admin, remove_user, revoke_user_sub,
+                   get_users_count, get_users_for_review, remove_admin, remove_user, revoke_user_sub,
                    set_owner, update_admin, update_user, update_user_status, reset_user_by_next,
                    update_user_sub, start_user_expire, get_admin_by_id,
                    get_admin_by_telegram_id)
@@ -41,6 +41,7 @@ __all__ = [
     "get_user_by_id",
     "get_users",
     "get_users_count",
+    "get_users_for_review",
     "create_user",
     "remove_user",
     "update_user",


### PR DESCRIPTION
Added get_users_for_review() function that filters active users who are logically limited (used_traffic >= data_limit) or expired (expire <= now_ts) at the database level instead of fetching all active users and filtering in Python. This reduces database transfer and memory usage significantly for large user bases.