### PR TITLE
Update APScheduler dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-APScheduler==3.9.1.post1
+APScheduler==3.10.4
 Deprecated==1.2.13
 Jinja2==3.1.4
 MarkupSafe==2.1.1


### PR DESCRIPTION
## Summary
- bump APScheduler to 3.10.4 to avoid pkg_resources deprecation warning

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69488ac16494832da00065a08c16e14b)