### PR TITLE
Validate proxies presence on user creation

### DIFF
--- a/app/models/user.py
+++ b/app/models/user.py
@@ -151,6 +151,13 @@ class UserCreate(User):
         }
     })
 
+    @model_validator(mode="before")
+    @classmethod
+    def validate_required_proxies(cls, data):
+        if not data.get("proxies"):
+            raise ValueError("Each user needs at least one proxy")
+        return data
+
     @property
     def excluded_inbounds(self):
         excluded = {}


### PR DESCRIPTION
## Summary
- add pre-validation on user creation to require proxies field

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6948700478d8832da5639e59e82825b3)