### PR TITLE
fix: Catch TimeoutError in inbound user operations

### DIFF
--- a/app/xray/operations.py
+++ b/app/xray/operations.py
@@ -32,7 +32,7 @@ def get_tls():
 def _add_user_to_inbound(api: XRayAPI, inbound_tag: str, account: Account):
     try:
         api.add_inbound_user(tag=inbound_tag, user=account, timeout=300)
-    except (xray.exc.EmailExistsError, xray.exc.ConnectionError):
+    except (xray.exc.EmailExistsError, xray.exc.ConnectionError, xray.exc.TimeoutError):
         pass
 
 
@@ -40,7 +40,7 @@ def _add_user_to_inbound(api: XRayAPI, inbound_tag: str, account: Account):
 def _remove_user_from_inbound(api: XRayAPI, inbound_tag: str, email: str):
     try:
         api.remove_inbound_user(tag=inbound_tag, email=email, timeout=300)
-    except (xray.exc.EmailNotFoundError, xray.exc.ConnectionError):
+    except (xray.exc.EmailNotFoundError, xray.exc.ConnectionError, xray.exc.TimeoutError):
         pass
 
 
@@ -48,11 +48,11 @@ def _remove_user_from_inbound(api: XRayAPI, inbound_tag: str, email: str):
 def _alter_inbound_user(api: XRayAPI, inbound_tag: str, account: Account):
     try:
         api.remove_inbound_user(tag=inbound_tag, email=account.email, timeout=300)
-    except (xray.exc.EmailNotFoundError, xray.exc.ConnectionError):
+    except (xray.exc.EmailNotFoundError, xray.exc.ConnectionError, xray.exc.TimeoutError):
         pass
     try:
         api.add_inbound_user(tag=inbound_tag, user=account, timeout=300)
-    except (xray.exc.EmailExistsError, xray.exc.ConnectionError):
+    except (xray.exc.EmailExistsError, xray.exc.ConnectionError, xray.exc.TimeoutError):
         pass
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-APScheduler==3.9.1.post1
+APScheduler==3.10.4
 Deprecated==1.2.13
 Jinja2==3.1.4
 MarkupSafe==2.1.1


### PR DESCRIPTION
This PR adds exception handling for \TimeoutError\ (gRPC \DEADLINE_EXCEEDED\) in the threaded inbound user operations (\_add_user_to_inbound\, \_remove_user_from_inbound\, \_alter_inbound_user\). Under heavy load, these calls can timeout, and without this catch, the unhandled exception crashes the worker threads.