### PR TITLE
perf: optimize on_hold users review with database-level filtering

### DIFF
--- a/app/db/__init__.py
+++ b/app/db/__init__.py
@@ -31,7 +31,7 @@ from .crud import (create_admin, create_notification_reminder,  # noqa
                    get_users_count, get_users_for_review, remove_admin, remove_user, revoke_user_sub,
                    set_owner, update_admin, update_user, update_user_status, reset_user_by_next,
                    update_user_sub, start_user_expire, get_admin_by_id,
-                   get_admin_by_telegram_id)
+                   get_admin_by_telegram_id, get_onhold_users_for_review)
 
 from .models import JWT, System, User  # noqa
 
@@ -42,6 +42,7 @@ __all__ = [
     "get_users",
     "get_users_count",
     "get_users_for_review",
+    "get_onhold_users_for_review",
     "create_user",
     "remove_user",
     "update_user",

--- a/app/db/__init__.py
+++ b/app/db/__init__.py
@@ -28,10 +28,11 @@ from .crud import (create_admin, create_notification_reminder,  # noqa
                    get_admins, get_jwt_secret_key, get_notification_reminder,
                    get_or_create_inbound, get_system_usage,
                    get_tls_certificate, get_user, get_user_by_id, get_users,
-                   get_users_count, get_users_for_review, remove_admin, remove_user, revoke_user_sub,
+                   get_users_count, get_users_for_review, get_users_onhold_for_review,
+                   remove_admin, remove_user, revoke_user_sub,
                    set_owner, update_admin, update_user, update_user_status, reset_user_by_next,
                    update_user_sub, start_user_expire, get_admin_by_id,
-                   get_admin_by_telegram_id, get_onhold_users_for_review)
+                   get_admin_by_telegram_id)
 
 from .models import JWT, System, User  # noqa
 
@@ -42,7 +43,7 @@ __all__ = [
     "get_users",
     "get_users_count",
     "get_users_for_review",
-    "get_onhold_users_for_review",
+    "get_users_onhold_for_review",
     "create_user",
     "remove_user",
     "update_user",

--- a/app/jobs/review_users.py
+++ b/app/jobs/review_users.py
@@ -5,7 +5,7 @@ from sqlalchemy.orm import Session
 
 from app import logger, scheduler, xray
 from app.db import (GetDB, get_notification_reminder, get_users,
-                    get_users_for_review, start_user_expire, update_user_status,
+                    get_users_for_review, get_onhold_users_for_review, start_user_expire, update_user_status,
                     reset_user_by_next)
 from app.models.user import ReminderType, UserResponse, UserStatus
 from app.utils import report
@@ -93,23 +93,8 @@ def review():
             for user in get_users(db, status=UserStatus.active):
                 add_notification_reminders(db, user, now)
 
-        for user in get_users(db, status=UserStatus.on_hold):
-
-            if user.edit_at:
-                base_time = datetime.timestamp(user.edit_at)
-            else:
-                base_time = datetime.timestamp(user.created_at)
-
-            # Check if the user is online After or at 'base_time'
-            if user.online_at and base_time <= datetime.timestamp(user.online_at):
-                status = UserStatus.active
-
-            elif user.on_hold_timeout and (datetime.timestamp(user.on_hold_timeout) <= (now_ts)):
-                # If the user didn't connect within the timeout period, change status to "Active"
-                status = UserStatus.active
-
-            else:
-                continue
+        for user in get_onhold_users_for_review(db, now):
+            status = UserStatus.active
 
             update_user_status(db, user, status)
             start_user_expire(db, user)

--- a/app/jobs/review_users.py
+++ b/app/jobs/review_users.py
@@ -5,7 +5,8 @@ from sqlalchemy.orm import Session
 
 from app import logger, scheduler, xray
 from app.db import (GetDB, get_notification_reminder, get_users,
-                    get_users_for_review, get_onhold_users_for_review, start_user_expire, update_user_status,
+                    get_users_for_review, get_users_onhold_for_review,
+                    start_user_expire, update_user_status,
                     reset_user_by_next)
 from app.models.user import ReminderType, UserResponse, UserStatus
 from app.utils import report
@@ -93,7 +94,8 @@ def review():
             for user in get_users(db, status=UserStatus.active):
                 add_notification_reminders(db, user, now)
 
-        for user in get_onhold_users_for_review(db, now):
+        # Optimized check for on_hold users who need to be activated
+        for user in get_users_onhold_for_review(db, now):
             status = UserStatus.active
 
             update_user_status(db, user, status)


### PR DESCRIPTION
This PR optimizes the eview_users job by moving the filtering logic for on_hold users to the database level. 

### Changes:
- Added get_users_onhold_for_review to pp/db/crud.py to fetch only users that need activation.
- Updated pp/jobs/review_users.py to use this optimized query.
- Exported the new function in pp/db/__init__.py.

These changes reduce memory usage by avoiding loading all on_hold users into memory and improve performance by utilizing database-level filtering.