### PR TITLE
feat(db): add READ COMMITTED isolation level to reduce MySQL deadlocks

### DIFF
--- a/app/db/base.py
+++ b/app/db/base.py
@@ -19,7 +19,8 @@ else:
         pool_size=SQLALCHEMY_POOL_SIZE,
         max_overflow=SQLIALCHEMY_MAX_OVERFLOW,
         pool_recycle=3600,
-        pool_timeout=10
+        pool_timeout=10,
+        isolation_level="READ COMMITTED"
     )
 
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)


### PR DESCRIPTION
- Configure SQLAlchemy engine with isolation_level='READ COMMITTED' for MySQL
- Reduces row lock contention and deadlock frequency in high-concurrency scenarios