### PR TITLE
Separate on-hold user activation into its own scheduled job

### DIFF
--- a/app/jobs/review_onhold_users.py
+++ b/app/jobs/review_onhold_users.py
@@ -1,0 +1,49 @@
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy.orm.exc import ObjectDeletedError
+from sqlalchemy.exc import SQLAlchemyError
+
+from app import logger, scheduler
+from app.db import GetDB, get_onhold_users_for_review, start_user_expire, update_user_status
+from app.models.user import UserResponse, UserStatus
+from app.utils import report
+from config import JOB_REVIEW_USERS_INTERVAL
+
+if TYPE_CHECKING:
+    from app.db.models import User
+
+
+def review_onhold_users():
+    now = datetime.utcnow()
+    with GetDB() as db:
+        for user in get_onhold_users_for_review(db, now):
+            try:
+                status = UserStatus.active
+
+                update_user_status(db, user, status)
+                start_user_expire(db, user)
+
+                report.status_change(
+                    username=user.username,
+                    status=status,
+                    user=UserResponse.model_validate(user),
+                    user_admin=user.admin,
+                )
+
+                logger.info(f"User \"{user.username}\" status changed to {status}")
+            except ObjectDeletedError:
+                logger.warning("User object deleted during on-hold review, skipping.")
+            except SQLAlchemyError:
+                logger.exception("Database error while reviewing on-hold users")
+            except Exception:
+                logger.exception("Unknown error while reviewing on-hold users")
+
+
+scheduler.add_job(
+    review_onhold_users,
+    "interval",
+    seconds=JOB_REVIEW_USERS_INTERVAL,
+    coalesce=True,
+    max_instances=1,
+)

--- a/app/jobs/review_users.py
+++ b/app/jobs/review_users.py
@@ -7,8 +7,7 @@ from sqlalchemy.exc import SQLAlchemyError
 
 from app import logger, scheduler, xray
 from app.db import (GetDB, get_notification_reminder, get_users,
-                    get_users_for_review, get_onhold_users_for_review,
-                    start_user_expire, update_user_status,
+                    get_users_for_review, update_user_status,
                     reset_user_by_next)
 from app.models.user import ReminderType, UserResponse, UserStatus
 from app.utils import report
@@ -102,17 +101,6 @@ def review():
         if WEBHOOK_ADDRESS:
             for user in get_users(db, status=UserStatus.active):
                 add_notification_reminders(db, user, now)
-
-        for user in get_onhold_users_for_review(db, now):
-            status = UserStatus.active
-
-            update_user_status(db, user, status)
-            start_user_expire(db, user)
-
-            report.status_change(username=user.username, status=status,
-                                 user=UserResponse.model_validate(user), user_admin=user.admin)
-
-            logger.info(f"User \"{user.username}\" status changed to {status}")
 
 
 scheduler.add_job(review, 'interval',


### PR DESCRIPTION
### Motivation

- Split on-hold user activation out of the general review job so the limited/expired review can remain focused on usage/expiration checks.

### Description

- Added a new scheduled job in `app/jobs/review_onhold_users.py` that implements `review_onhold_users` which queries `get_onhold_users_for_review` and activates users by calling `update_user_status` and `start_user_expire`, then reports via `report.status_change` and logs the change.
- Removed the on-hold activation block from `app/jobs/review_users.py` and adjusted imports to keep that job dedicated to limited/expired user handling and notification reminders.
- Added explicit error handling for `ObjectDeletedError`, `SQLAlchemyError`, and generic exceptions in the new job, and registered it with `scheduler.add_job` using `JOB_REVIEW_USERS_INTERVAL`.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69773fcf8924832d9dfee298309fa229)